### PR TITLE
(fix) Use absolute paths to avoid ambiguity with relative paths.

### DIFF
--- a/packages/cicero-core/lib/template.js
+++ b/packages/cicero-core/lib/template.js
@@ -741,7 +741,8 @@ class Template {
         const isFileInNodeModuleDir = function (file, basePath) {
             const method = 'isFileInNodeModuleDir';
             let filePath = fsPath.parse(file);
-            let subPath = filePath.dir.substring(basePath.length-1);
+            basePath = fsPath.resolve(basePath);
+            let subPath = fsPath.resolve(filePath.dir).substring(basePath.length);
             let result = subPath.split(fsPath.sep).some((element) => {
                 return element === 'node_modules';
             });


### PR DESCRIPTION
Related to #23 