### PR TITLE
(feature) Initial Jura integration into Cicero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package cicero
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ Now edit the business logic of the template itself. At present this is expressed
 
 TBD.
 
-© 2017 Clause, Inc.
+© 2017-2018 Clause, Inc.

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.43",
+  "version": "0.2.44",
   "hoist": true,
   "command": {
     "publish": {

--- a/packages/cicero-cli/CHANGELOG.md
+++ b/packages/cicero-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package cicero-cli
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -21,14 +21,23 @@ const Commands = require('./lib/commands');
 require('yargs')
     .command('parse', 'parse dsl text using a template', (yargs) => {
         yargs.option('template', {
-            describe: 'path to the directory with the template'
+            describe: 'path to the directory with the template',
+            type: 'string'
         });
         yargs.option('dsl', {
-            describe: 'path to the clause text'
+            describe: 'path to the clause text',
+            type: 'string'
         });
     }, (argv) => {
         if (argv.verbose) {
             logger.info(`parse dsl ${argv.dsl} using a template ${argv.template}`);
+        }
+
+        try {
+            argv = Commands.validateParseArgs(argv);
+        } catch (err){
+            logger.error(err.message);
+            return;
         }
 
         return Commands.parse(argv.template, argv.dsl)
@@ -41,17 +50,24 @@ require('yargs')
     })
     .command('execute', 'execute a clause with JSON data', (yargs) => {
         yargs.option('template', {
-            describe: 'path to the directory with the template'
+            describe: 'path to the directory with the template',
+            type: 'string'
         });
         yargs.option('dsl', {
-            describe: 'path to the clause text'
+            describe: 'path to the clause text',
+            type: 'string'
         });
         yargs.option('data', {
-            describe: 'path to the request JSON data'
+            describe: 'path to the request JSON data',
+            type: 'string'
         });
     }, (argv) => {
-        if (argv.verbose) {
-            logger.info(`execute dsl ${argv.dsl} using a template ${argv.template} with data ${argv.data}`);
+
+        try {
+            argv = Commands.validateExecuteArgs(argv);
+        } catch (err){
+            logger.error(err.message);
+            return;
         }
 
         return Commands.execute(argv.template, argv.dsl, argv.data)
@@ -64,17 +80,30 @@ require('yargs')
     })
     .command('generate', 'generate code from the template model', (yargs) => {
         yargs.option('template', {
-            describe: 'path to the directory with the template'
+            describe: 'path to the directory with the template',
+            type: 'string',
+            default: '.'
         });
         yargs.option('format', {
-            describe: 'format of the code to generate'
+            describe: 'format of the code to generate',
+            type: 'string',
+            default: 'JSONSchema'
         });
         yargs.option('outputDirectory', {
-            describe: 'output directory path'
+            describe: 'output directory path',
+            type: 'string',
+            default: './output/'
         });
     }, (argv) => {
         if (argv.verbose) {
             logger.info(`generate code in format ${argv.format} from the model for template ${argv.template} into directory ${argv.outputDirectory}`);
+        }
+
+        try {
+            argv = Commands.validateExecuteArgs(argv);
+        } catch (err){
+            logger.error(err.message);
+            return;
         }
 
         return Commands.generate(argv.format, argv.template, argv.outputDirectory)

--- a/packages/cicero-cli/package-lock.json
+++ b/packages/cicero-cli/package-lock.json
@@ -1,11 +1,5894 @@
 {
-	"requires": true,
+	"name": "cicero-cli",
+	"version": "0.2.42",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+			"integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/inquire": "1.1.0"
+			}
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+		},
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"@types/long": {
+			"version": "3.0.32",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+			"optional": true
+		},
+		"@types/node": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+			"integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs="
+		},
+		"abbrev": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"axios": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"requires": {
+				"follow-redirects": "1.4.1",
+				"is-buffer": "1.1.6"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				}
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"browserfs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+			"integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+			"requires": {
+				"async": "2.6.0",
+				"pako": "1.0.6"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"requires": {
+				"pako": "0.2.9"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				}
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chai": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"dev": true,
+			"requires": {
+				"assertion-error": "1.1.0",
+				"deep-eql": "0.1.3",
+				"type-detect": "1.0.0"
+			}
+		},
+		"chai-as-promised": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+			"integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+			"dev": true,
+			"requires": {
+				"check-error": "1.0.2"
+			}
+		},
+		"chai-things": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+			"integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
+		"cicero-core": {
+			"version": "0.2.42",
+			"resolved": "https://registry.npmjs.org/cicero-core/-/cicero-core-0.2.42.tgz",
+			"integrity": "sha512-xQX+fN9ClI0BRBP04jEFAgO+BP59CiFHBoHYAUV/0zMFU5ZYaD70xGTUb7gVi/0lgjjxBMBPHiTPFyyTC4+5RQ==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"config": "1.29.4",
+				"debug": "2.6.9",
+				"glob": "7.1.2",
+				"gunzip-maybe": "1.4.1",
+				"ietf-language-tag-regex": "0.0.5",
+				"jszip": "3.1.5",
+				"minimatch": "3.0.4",
+				"moment": "2.20.1",
+				"moo": "0.4.3",
+				"nearley": "2.11.1",
+				"request-promise-native": "1.0.5",
+				"stream-to-string": "1.1.0",
+				"streamifier": "0.1.1",
+				"tar-fs": "1.16.0",
+				"tar-stream": "1.5.5",
+				"tmp-promise": "1.0.4",
+				"winston": "2.4.0",
+				"xregexp": "4.0.0"
+			}
+		},
+		"cicero-engine": {
+			"version": "0.2.42",
+			"resolved": "https://registry.npmjs.org/cicero-engine/-/cicero-engine-0.2.42.tgz",
+			"integrity": "sha512-cn70awGSArnMOlVIOPuGBW5F9mudoEntPDM8HN9uFfql06Ov3w7PSYW6IYga/YQvVOA13QjN5YbTEUdc2IbqkA==",
+			"requires": {
+				"cicero-core": "0.2.42",
+				"composer-common": "0.17.4",
+				"config": "1.29.4",
+				"debug": "2.6.9",
+				"moment": "2.20.1",
+				"nearley": "2.11.1",
+				"vm2": "3.5.2",
+				"winston": "2.4.0"
+			}
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
+		},
+		"colors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"comment-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+			"integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"composer-common": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.17.4.tgz",
+			"integrity": "sha512-/L6qSq9XbbEbQGvcR6qBd51Eezixt4R9MLJ50ZKUeoW2RzxFVLeHozwXuTsooXVAC3/PCyTE711MmcNNRnNT8Q==",
+			"requires": {
+				"acorn": "5.1.2",
+				"axios": "0.17.1",
+				"browserfs": "1.1.0",
+				"commander": "2.9.0",
+				"comment-parser": "0.4.0",
+				"config": "1.24.0",
+				"debug": "2.6.2",
+				"doctrine": "2.0.0",
+				"esprima": "3.1.2",
+				"fs-promise": "1.0.0",
+				"homedir": "0.6.0",
+				"js-yaml": "3.10.0",
+				"jszip": "3.1.3",
+				"left-pad": "1.1.3",
+				"lorem-ipsum": "1.0.4",
+				"minimatch": "3.0.3",
+				"mkdirp": "0.5.1",
+				"node-plantuml": "0.5.0",
+				"protobufjs": "6.6.3",
+				"proxyquire": "1.7.11",
+				"rimraf": "2.5.4",
+				"semver": "5.3.0",
+				"sprintf-js": "1.0.3",
+				"temp": "0.8.3",
+				"thenify": "3.2.1",
+				"thenify-all": "1.6.0",
+				"uri-js": "3.0.2",
+				"uuid": "3.0.1",
+				"winston": "2.3.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"config": {
+					"version": "1.24.0",
+					"resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+					"integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+					"requires": {
+						"json5": "0.4.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+					"integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+					"requires": {
+						"ms": "0.7.2"
+					}
+				},
+				"jszip": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+					"integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+					"requires": {
+						"core-js": "2.3.0",
+						"es6-promise": "3.0.2",
+						"lie": "3.1.1",
+						"pako": "1.0.6",
+						"readable-stream": "2.0.6"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"ms": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"winston": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+					"integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+					"requires": {
+						"async": "1.0.0",
+						"colors": "1.0.3",
+						"cycle": "1.0.3",
+						"eyes": "0.1.8",
+						"isstream": "0.1.2",
+						"stack-trace": "0.0.10"
+					}
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"typedarray": "0.0.6"
+			}
+		},
+		"config": {
+			"version": "1.29.4",
+			"resolved": "https://registry.npmjs.org/config/-/config-1.29.4.tgz",
+			"integrity": "sha1-G0J1LthrNj/EAllgVp/XSXiGKpI=",
+			"requires": {
+				"json5": "0.4.0",
+				"os-homedir": "1.0.2"
+			}
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+			"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-eql": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"dev": true,
+			"requires": {
+				"type-detect": "0.1.1"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+					"dev": true
+				}
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.5.4"
+			}
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+			"dev": true
+		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+		},
+		"doctrine": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"requires": {
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
+			}
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
+			"requires": {
+				"esprima": "2.7.3",
+				"estraverse": "1.9.3",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.2.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
+				}
+			}
+		},
+		"eslint": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+			"integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.1",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.3",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.3.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.3.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "2.0.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.4.1",
+				"acorn-jsx": "3.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+			"integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ="
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				}
+			}
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"dev": true,
+			"requires": {
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "1.0.1",
+				"merge-descriptors": "1.0.1"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
+			}
+		},
+		"fs-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+			"integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+			"requires": {
+				"any-promise": "1.3.0",
+				"fs-extra": "1.0.0",
+				"mz": "2.7.0",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"globals": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+			"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+			"dev": true
+		},
+		"globby": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
+		},
+		"gulp-license-check": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
+			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"gulp-util": "3.0.8",
+				"through2": "2.0.3",
+				"vinyl-file": "2.0.0"
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.2",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "1.0.1"
+			}
+		},
+		"gunzip-maybe": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+			"integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+			"requires": {
+				"browserify-zlib": "0.1.4",
+				"is-deflate": "1.0.0",
+				"is-gzip": "1.0.0",
+				"peek-stream": "1.1.2",
+				"pumpify": "1.4.0",
+				"through2": "2.0.3"
+			}
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"homedir": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+			"integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4="
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
+		"ietf-language-tag-regex": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/ietf-language-tag-regex/-/ietf-language-tag-regex-0.0.5.tgz",
+			"integrity": "sha1-gRM62z0ckpuP8fRyVEkK7no0Ys4=",
+			"requires": {
+				"xregexp": "3.2.0"
+			},
+			"dependencies": {
+				"xregexp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+					"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+				}
+			}
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-deflate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+			"integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9",
+				"async": "1.5.2",
+				"escodegen": "1.8.1",
+				"esprima": "2.7.3",
+				"glob": "5.0.15",
+				"handlebars": "4.0.11",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"once": "1.4.0",
+				"resolve": "1.1.7",
+				"supports-color": "3.2.3",
+				"which": "1.3.0",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				}
+			}
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+			"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jszip": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+			"integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+			"requires": {
+				"core-js": "2.3.0",
+				"es6-promise": "3.0.2",
+				"lie": "3.1.1",
+				"pako": "1.0.6",
+				"readable-stream": "2.0.6"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"just-extend": {
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+			"integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"license-check": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
+			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
+			"dev": true,
+			"requires": {
+				"gulp-license-check": "1.2.1",
+				"gulp-util": "3.0.8",
+				"istanbul": "0.4.5",
+				"pkg-conf": "1.1.3",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+			"requires": {
+				"immediate": "3.0.6"
+			}
+		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basecreate": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
+		"lodash.create": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+			"dev": true,
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._basecreate": "3.0.3",
+				"lodash._isiterateecall": "3.0.9"
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lolex": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
+		},
+		"long": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"optional": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"lorem-ipsum": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+			"integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+			"requires": {
+				"optimist": "0.3.7"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.8",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
+				"growl": "1.9.2",
+				"he": "1.1.1",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "3.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"mockery": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+			"integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+			"dev": true
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+		},
 		"moment": {
 			"version": "2.20.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
 			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+		},
+		"moo": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"requires": {
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"nearley": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
+			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+			"requires": {
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
+				"randexp": "0.4.6",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				}
+			}
+		},
+		"nise": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
+			"integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "1.1.27",
+				"lolex": "2.3.2",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
+			}
+		},
+		"node-nailgun-client": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+			"integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-nailgun-server": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+			"integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-plantuml": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+			"integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+			"requires": {
+				"commander": "2.9.0",
+				"node-nailgun-client": "0.1.0",
+				"node-nailgun-server": "0.1.3",
+				"plantuml-encoder": "1.2.5"
+			}
+		},
+		"nomnom": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"requires": {
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+					"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+				}
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.3.0",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nyc": {
+			"version": "11.4.1",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
+			"requires": {
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.1",
+				"istanbul-lib-report": "1.1.2",
+				"istanbul-lib-source-maps": "1.2.2",
+				"istanbul-reports": "1.1.3",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.0.4",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.1.1",
+				"yargs": "10.0.3",
+				"yargs-parser": "8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true,
+					"dev": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.4",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"core-js": "2.5.3",
+						"regenerator-runtime": "0.11.1"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.8",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"bundled": true,
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "4.1.1",
+						"which": "1.3.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"strip-bom": "2.0.0"
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lru-cache": "4.1.1",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"amdefine": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "2.5.0",
+					"bundled": true,
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"invariant": {
+					"version": "2.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"append-transform": "0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.9.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-generator": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"semver": "5.4.1"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"handlebars": "4.0.11"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"bundled": true,
+					"dev": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mimic-fn": "1.1.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.4.1",
+						"validate-npm-package-license": "3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "2.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "1.1.0"
+					}
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true,
+					"dev": true
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true,
+					"dev": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.4.1",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true,
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-license-ids": "1.2.2"
+					}
+				},
+				"spdx-expression-parse": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-license-ids": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"micromatch": "2.3.11",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-correct": "1.0.2",
+						"spdx-expression-parse": "1.0.4"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.0.0"
+					},
+					"dependencies": {
+						"cliui": {
+							"version": "3.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wrap-ansi": "2.1.0"
+							},
+							"dependencies": {
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									}
+								}
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"optimist": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+			"requires": {
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"peek-stream": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
+			"integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
+			"requires": {
+				"duplexify": "3.5.3",
+				"through2": "2.0.3"
+			}
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"load-json-file": "1.1.0",
+				"object-assign": "4.1.1",
+				"symbol": "0.2.3"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"plantuml-encoder": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.5.tgz",
+			"integrity": "sha512-viV7Sz+BJNX/sC3iyebh2VfLyAZKuu3+JuBs2ISms8+zoTGwPqwk3/WEDw/zROmGAJ/xD4sNd8zsBw/YmTo7ng==",
+			"requires": {
+				"pako": "1.0.3",
+				"utf8-bytes": "0.0.1"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+					"integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8="
+				}
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
+		},
+		"promise-polyfill": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+			"integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+		},
+		"protobufjs": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+			"integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/base64": "1.1.2",
+				"@protobufjs/codegen": "1.0.8",
+				"@protobufjs/eventemitter": "1.1.0",
+				"@protobufjs/fetch": "1.1.0",
+				"@protobufjs/inquire": "1.1.0",
+				"@protobufjs/path": "1.1.2",
+				"@protobufjs/pool": "1.1.0",
+				"@protobufjs/utf8": "1.1.0",
+				"@types/long": "3.0.32",
+				"@types/node": "7.0.4",
+				"long": "3.2.0"
+			}
+		},
+		"proxyquire": {
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+			"integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+			"requires": {
+				"fill-keys": "1.0.2",
+				"module-not-found-error": "1.0.1",
+				"resolve": "1.1.7"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.3",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "0.1.15"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"requires": {
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"requires": {
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+			"integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"samsam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"sinon": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
+			"integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.2.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.3.2",
+				"nise": "1.2.5",
+				"supports-color": "5.2.0",
+				"type-detect": "4.0.8"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+					"dev": true
+				}
+			}
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+			"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"stream-to-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+			"requires": {
+				"promise-polyfill": "1.1.6"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"symbol": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+			"dev": true
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.1",
+				"lodash": "4.17.5",
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			}
+		},
+		"tar-fs": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+			"requires": {
+				"chownr": "1.0.1",
+				"mkdirp": "0.5.1",
+				"pump": "1.0.3",
+				"tar-stream": "1.5.5"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"requires": {
+				"bl": "1.2.1",
+				"end-of-stream": "1.4.1",
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+				}
+			}
+		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"thenify": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+			"integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+			"requires": {
+				"any-promise": "1.3.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+			"requires": {
+				"thenify": "3.2.1"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmp-promise": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"tmp": "0.0.33"
+			}
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"requires": {
+				"punycode": "1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
+			}
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"dev": true
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true,
+					"optional": true
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"underscore": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"uri-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"requires": {
+				"punycode": "2.1.0"
+			}
+		},
+		"utf8-bytes": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+			"integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.3",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.4",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"first-chunk-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-bom-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+					"dev": true,
+					"requires": {
+						"first-chunk-stream": "1.0.0",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vm2": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+			"integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg=="
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"winston": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+			"integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+			"requires": {
+				"async": "1.0.0",
+				"colors": "1.0.3",
+				"cycle": "1.0.3",
+				"eyes": "0.1.8",
+				"isstream": "0.1.2",
+				"stack-trace": "0.0.10"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				}
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
+		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"requires": {
+				"camelcase": "4.1.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "7.0.0"
+			}
+		},
+		"yargs-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"requires": {
+				"camelcase": "4.1.0"
+			}
 		}
 	}
 }

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cicero-cli",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Cicero CLI",
   "engines": {
     "node": ">=8",
@@ -44,8 +44,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.43",
-    "cicero-engine": "^0.2.43",
+    "cicero-core": "^0.2.44",
+    "cicero-engine": "^0.2.44",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -26,26 +26,103 @@ describe('cicero-cli', () => {
     const template = path.resolve(__dirname, 'data/latedeliveryandpenalty/');
     const sample = path.resolve(__dirname, 'data/latedeliveryandpenalty/', 'sample.txt');
     const data = path.resolve(__dirname, 'data/latedeliveryandpenalty/', 'data.json');
+    const parseReponse = {
+        '$class':'org.accordproject.latedeliveryandpenalty.TemplateModel',
+        'forceMajeure':true,
+        'penaltyDuration':{
+            '$class':'org.accordproject.latedeliveryandpenalty.Duration',
+            'amount':9,
+            'unit':'DAY'
+        },
+        'penaltyPercentage':7,
+        'capPercentage':2,
+        'termination':{
+            '$class':'org.accordproject.latedeliveryandpenalty.Duration',
+            'amount':2,
+            'unit':'WEEK'
+        },
+        'fractionalPart':'DAY'
+    };
 
     describe('#parse', () => {
         it('should parse a clause using a template', () => {
-            return Commands.parse(template, sample).should.eventually.eql({
-                '$class':'org.accordproject.latedeliveryandpenalty.TemplateModel',
-                'forceMajeure':true,
-                'penaltyDuration':{
-                    '$class':'org.accordproject.latedeliveryandpenalty.Duration',
-                    'amount':9,
-                    'unit':'DAY'
-                },
-                'penaltyPercentage':7,
-                'capPercentage':2,
-                'termination':{
-                    '$class':'org.accordproject.latedeliveryandpenalty.Duration',
-                    'amount':2,
-                    'unit':'WEEK'
-                },
-                'fractionalPart':'DAY'
+            return Commands.parse(template, sample, true).should.eventually.eql(parseReponse);
+        });
+    });
+
+    describe('#validateParseArgs', () => {
+        it('no args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            const args  = Commands.validateParseArgs({
+                _: ['parse'],
             });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            const args  = Commands.validateParseArgs({
+                _: ['parse'],
+                template: './',
+                dsl: 'sample.txt'
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, parent folder', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            const args  = Commands.validateParseArgs({
+                _: ['parse'],
+                template: 'latedeliveryandpenalty',
+                dsl: 'latedeliveryandpenalty/sample.txt'
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, parent folder, no dsl', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            const args  = Commands.validateParseArgs({
+                _: ['parse'],
+                template: 'latedeliveryandpenalty',
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, child folder, no dsl', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/grammar'));
+            const args  = Commands.validateParseArgs({
+                _: ['parse'],
+                template: '../',
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('no flags specified', () => {
+            const args  = Commands.validateParseArgs({
+                _: ['parse', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('verbose flag specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            Commands.validateParseArgs({
+                _: ['parse'],
+                verbose: true
+            });
+        });
+        it('bad package.json', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            (() => Commands.validateParseArgs({
+                _: ['parse'],
+            })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a engines.cicero entry.');
+        });
+        it('bad sample.txt', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            (() => Commands.validateParseArgs({
+                _: ['parse'],
+                dsl: 'sample_en.txt'
+            })).should.throw('A sample text file is required. Try the --dsl flag or create a sample.txt in the root folder of your template.');
         });
     });
 
@@ -55,6 +132,89 @@ describe('cicero-cli', () => {
             response.response.$class.should.be.equal('org.accordproject.latedeliveryandpenalty.LateDeliveryAndPenaltyResponse');
             response.response.penalty.should.be.equal(4);
             response.response.buyerMayTerminate.should.be.equal(false);
+        });
+    });
+
+    describe('#validateExecuteArgs', () => {
+        it('no args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute'],
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute'],
+                template: './',
+                dsl: 'sample.txt'
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, parent folder', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute'],
+                template: 'latedeliveryandpenalty',
+                dsl: 'latedeliveryandpenalty/sample.txt'
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, parent folder, no dsl', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute'],
+                template: 'latedeliveryandpenalty',
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('all args specified, child folder, no dsl', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/grammar'));
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute'],
+                template: '../',
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('no flags specified', () => {
+            const args  = Commands.validateExecuteArgs({
+                _: ['execute', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
+            });
+            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.dsl.should.match(/sample.txt$/);
+        });
+        it('verbose flag specified', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            Commands.validateExecuteArgs({
+                _: ['execute'],
+                verbose: true
+            });
+        });
+        it('bad package.json', () => {
+            process.chdir(path.resolve(__dirname, 'data/'));
+            (() => Commands.validateExecuteArgs({
+                _: ['execute'],
+            })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a engines.cicero entry.');
+        });
+        it('bad sample.txt', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            (() => Commands.validateExecuteArgs({
+                _: ['execute'],
+                dsl: 'sample_en.txt'
+            })).should.throw('A sample text file is required. Try the --dsl flag or create a sample.txt in the root folder of your template.');
+        });
+        it('bad datajson', () => {
+            process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+            (() => Commands.validateExecuteArgs({
+                _: ['execute'],
+                data: 'data1.json'
+            })).should.throw('A data file is required. Try the --data flag or create a data.json in the root folder of your template.');
         });
     });
 

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/package.json
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/package.json
@@ -1,5 +1,8 @@
 {
     "name": "latedeliveryandpenalty",
     "version": "0.0.1",
-    "description": "Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract."
+    "description": "Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.",
+    "engines": {
+      "cicero": "^0.2.41"
+    }
   }

--- a/packages/cicero-core/CHANGELOG.md
+++ b/packages/cicero-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package cicero-core
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/packages/cicero-core/package-lock.json
+++ b/packages/cicero-core/package-lock.json
@@ -1,11 +1,5984 @@
 {
-	"requires": true,
+	"name": "cicero-core",
+	"version": "0.2.44",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+			"integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/inquire": "1.1.0"
+			}
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+		},
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"@types/long": {
+			"version": "3.0.32",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+			"optional": true
+		},
+		"@types/node": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+			"integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs="
+		},
+		"abbrev": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"axios": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"requires": {
+				"follow-redirects": "1.4.1",
+				"is-buffer": "1.1.6"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				}
+			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.19",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"browserfs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+			"integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+			"requires": {
+				"async": "2.6.0",
+				"pako": "1.0.6"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"requires": {
+				"pako": "0.2.9"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				}
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+		},
+		"catharsis": {
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+			"integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+			"dev": true,
+			"requires": {
+				"underscore-contrib": "0.3.0"
+			}
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chai": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"dev": true,
+			"requires": {
+				"assertion-error": "1.1.0",
+				"deep-eql": "0.1.3",
+				"type-detect": "1.0.0"
+			}
+		},
+		"chai-as-promised": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+			"integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+			"dev": true,
+			"requires": {
+				"check-error": "1.0.2"
+			}
+		},
+		"chai-things": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+			"integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
+		},
+		"colors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"comment-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+			"integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"composer-common": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.17.4.tgz",
+			"integrity": "sha512-/L6qSq9XbbEbQGvcR6qBd51Eezixt4R9MLJ50ZKUeoW2RzxFVLeHozwXuTsooXVAC3/PCyTE711MmcNNRnNT8Q==",
+			"requires": {
+				"acorn": "5.1.2",
+				"axios": "0.17.1",
+				"browserfs": "1.1.0",
+				"commander": "2.9.0",
+				"comment-parser": "0.4.0",
+				"config": "1.24.0",
+				"debug": "2.6.2",
+				"doctrine": "2.0.0",
+				"esprima": "3.1.2",
+				"fs-promise": "1.0.0",
+				"homedir": "0.6.0",
+				"js-yaml": "3.10.0",
+				"jszip": "3.1.3",
+				"left-pad": "1.1.3",
+				"lorem-ipsum": "1.0.4",
+				"minimatch": "3.0.3",
+				"mkdirp": "0.5.1",
+				"node-plantuml": "0.5.0",
+				"protobufjs": "6.6.3",
+				"proxyquire": "1.7.11",
+				"rimraf": "2.5.4",
+				"semver": "5.3.0",
+				"sprintf-js": "1.0.3",
+				"temp": "0.8.3",
+				"thenify": "3.2.1",
+				"thenify-all": "1.6.0",
+				"uri-js": "3.0.2",
+				"uuid": "3.0.1",
+				"winston": "2.3.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"config": {
+					"version": "1.24.0",
+					"resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+					"integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+					"requires": {
+						"json5": "0.4.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+					"integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+					"requires": {
+						"ms": "0.7.2"
+					}
+				},
+				"jszip": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+					"integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+					"requires": {
+						"core-js": "2.3.0",
+						"es6-promise": "3.0.2",
+						"lie": "3.1.1",
+						"pako": "1.0.6",
+						"readable-stream": "2.0.6"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"ms": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"winston": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+					"integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+					"requires": {
+						"async": "1.0.0",
+						"colors": "1.0.3",
+						"cycle": "1.0.3",
+						"eyes": "0.1.8",
+						"isstream": "0.1.2",
+						"stack-trace": "0.0.10"
+					}
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"typedarray": "0.0.6"
+			}
+		},
+		"config": {
+			"version": "1.29.4",
+			"resolved": "https://registry.npmjs.org/config/-/config-1.29.4.tgz",
+			"integrity": "sha1-G0J1LthrNj/EAllgVp/XSXiGKpI=",
+			"requires": {
+				"json5": "0.4.0",
+				"os-homedir": "1.0.2"
+			}
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+			"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-eql": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"dev": true,
+			"requires": {
+				"type-detect": "0.1.1"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+					"dev": true
+				}
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.5.4"
+			}
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+			"dev": true
+		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+		},
+		"doctrine": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"requires": {
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
+			}
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
+			"requires": {
+				"esprima": "2.7.3",
+				"estraverse": "1.9.3",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.2.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
+				}
+			}
+		},
+		"eslint": {
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.0.tgz",
+			"integrity": "sha512-Ep2lUbztzXLg0gNUl48I1xvbQFy1QuWyh1C9PSympmln33jwOr8B3QfuEcXpPPE4uSwEzDaWhUxBN0sNQkzrBg==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.1",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.3",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.3.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.3.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "2.0.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.4.1",
+				"acorn-jsx": "3.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+			"integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ="
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				}
+			}
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"dev": true,
+			"requires": {
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "1.0.1",
+				"merge-descriptors": "1.0.1"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
+			}
+		},
+		"fs-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+			"integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+			"requires": {
+				"any-promise": "1.3.0",
+				"fs-extra": "1.0.0",
+				"mz": "2.7.0",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"globals": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+			"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+			"dev": true
+		},
+		"globby": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
+		},
+		"gulp-license-check": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
+			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"gulp-util": "3.0.8",
+				"through2": "2.0.3",
+				"vinyl-file": "2.0.0"
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.2",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "1.0.1"
+			}
+		},
+		"gunzip-maybe": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+			"integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+			"requires": {
+				"browserify-zlib": "0.1.4",
+				"is-deflate": "1.0.0",
+				"is-gzip": "1.0.0",
+				"peek-stream": "1.1.2",
+				"pumpify": "1.4.0",
+				"through2": "2.0.3"
+			}
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"homedir": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+			"integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4="
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
+		"ietf-language-tag-regex": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/ietf-language-tag-regex/-/ietf-language-tag-regex-0.0.5.tgz",
+			"integrity": "sha1-gRM62z0ckpuP8fRyVEkK7no0Ys4=",
+			"requires": {
+				"xregexp": "3.2.0"
+			},
+			"dependencies": {
+				"xregexp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+					"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+				}
+			}
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-deflate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+			"integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9",
+				"async": "1.5.2",
+				"escodegen": "1.8.1",
+				"esprima": "2.7.3",
+				"glob": "5.0.15",
+				"handlebars": "4.0.11",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"once": "1.4.0",
+				"resolve": "1.1.7",
+				"supports-color": "3.2.3",
+				"which": "1.3.0",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				}
+			}
+		},
+		"js2xmlparser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+			"dev": true,
+			"requires": {
+				"xmlcreate": "1.0.2"
+			}
+		},
+		"jsdoc": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+			"dev": true,
+			"requires": {
+				"babylon": "7.0.0-beta.19",
+				"bluebird": "3.5.1",
+				"catharsis": "0.8.9",
+				"escape-string-regexp": "1.0.5",
+				"js2xmlparser": "3.0.0",
+				"klaw": "2.0.0",
+				"marked": "0.3.15",
+				"mkdirp": "0.5.1",
+				"requizzle": "0.2.1",
+				"strip-json-comments": "2.0.1",
+				"taffydb": "2.6.2",
+				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"klaw": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+					"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+					"dev": true
+				}
+			}
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+			"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jszip": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+			"integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+			"requires": {
+				"core-js": "2.3.0",
+				"es6-promise": "3.0.2",
+				"lie": "3.1.1",
+				"pako": "1.0.6",
+				"readable-stream": "2.0.6"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"jura-compiler": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/jura-compiler/-/jura-compiler-0.0.11.tgz",
+			"integrity": "sha512-+ViM6YP09aFIvqSfK360aNz5p/N1fzMf8ciuCLD3DwrthiAQ/6Z/lBDgxMtBZKyvCCfI8xv7sgPFsLgsVSKFsw==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"moment": "2.20.1",
+				"nearley": "2.11.1",
+				"pegjs": "0.10.0",
+				"vm2": "3.5.2",
+				"yargs": "9.0.1"
+			}
+		},
+		"just-extend": {
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+			"integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"license-check": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
+			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
+			"dev": true,
+			"requires": {
+				"gulp-license-check": "1.2.1",
+				"gulp-util": "3.0.8",
+				"istanbul": "0.4.5",
+				"pkg-conf": "1.1.3",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+			"requires": {
+				"immediate": "3.0.6"
+			}
+		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basecreate": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
+		"lodash.create": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+			"dev": true,
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._basecreate": "3.0.3",
+				"lodash._isiterateecall": "3.0.9"
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lolex": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
+		},
+		"long": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"optional": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"lorem-ipsum": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+			"integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+			"requires": {
+				"optimist": "0.3.7"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
+		"marked": {
+			"version": "0.3.15",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.15.tgz",
+			"integrity": "sha512-PToZtmCYVf4mlkmfoDPpsg3VJhkEvCHeTXSxbG3FBBxEoLAlxAsYPCADWx4+XBebMXCowDW7vaOGfRVjmFDM5w==",
+			"dev": true
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.8",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
+				"growl": "1.9.2",
+				"he": "1.1.1",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "3.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"mockery": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+			"integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+			"dev": true
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+		},
 		"moment": {
 			"version": "2.20.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
 			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+		},
+		"moo": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"requires": {
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"nearley": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
+			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+			"requires": {
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
+				"randexp": "0.4.6",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				}
+			}
+		},
+		"nise": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
+			"integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "1.1.27",
+				"lolex": "2.3.2",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
+			}
+		},
+		"node-nailgun-client": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+			"integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-nailgun-server": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+			"integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-plantuml": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+			"integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+			"requires": {
+				"commander": "2.9.0",
+				"node-nailgun-client": "0.1.0",
+				"node-nailgun-server": "0.1.3",
+				"plantuml-encoder": "1.2.5"
+			}
+		},
+		"nomnom": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"requires": {
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+					"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+				}
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.3.0",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nyc": {
+			"version": "11.4.1",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
+			"requires": {
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.1",
+				"istanbul-lib-report": "1.1.2",
+				"istanbul-lib-source-maps": "1.2.2",
+				"istanbul-reports": "1.1.3",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.0.4",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.1.1",
+				"yargs": "10.0.3",
+				"yargs-parser": "8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true,
+					"dev": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.4",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"core-js": "2.5.3",
+						"regenerator-runtime": "0.11.1"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.8",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"bundled": true,
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "4.1.1",
+						"which": "1.3.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"strip-bom": "2.0.0"
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lru-cache": "4.1.1",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"amdefine": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "2.5.0",
+					"bundled": true,
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"invariant": {
+					"version": "2.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"append-transform": "0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.9.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-generator": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"semver": "5.4.1"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"handlebars": "4.0.11"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"bundled": true,
+					"dev": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mimic-fn": "1.1.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.4.1",
+						"validate-npm-package-license": "3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "2.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "1.1.0"
+					}
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true,
+					"dev": true
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true,
+					"dev": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.4.1",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true,
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-license-ids": "1.2.2"
+					}
+				},
+				"spdx-expression-parse": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-license-ids": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"micromatch": "2.3.11",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-correct": "1.0.2",
+						"spdx-expression-parse": "1.0.4"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.0.0"
+					},
+					"dependencies": {
+						"cliui": {
+							"version": "3.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wrap-ansi": "2.1.0"
+							},
+							"dependencies": {
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									}
+								}
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"optimist": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+			"requires": {
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"peek-stream": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
+			"integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
+			"requires": {
+				"duplexify": "3.5.3",
+				"through2": "2.0.3"
+			}
+		},
+		"pegjs": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"load-json-file": "1.1.0",
+				"object-assign": "4.1.1",
+				"symbol": "0.2.3"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"plantuml-encoder": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.5.tgz",
+			"integrity": "sha512-viV7Sz+BJNX/sC3iyebh2VfLyAZKuu3+JuBs2ISms8+zoTGwPqwk3/WEDw/zROmGAJ/xD4sNd8zsBw/YmTo7ng==",
+			"requires": {
+				"pako": "1.0.3",
+				"utf8-bytes": "0.0.1"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+					"integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8="
+				}
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
+		},
+		"promise-polyfill": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+			"integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+		},
+		"protobufjs": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+			"integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/base64": "1.1.2",
+				"@protobufjs/codegen": "1.0.8",
+				"@protobufjs/eventemitter": "1.1.0",
+				"@protobufjs/fetch": "1.1.0",
+				"@protobufjs/inquire": "1.1.0",
+				"@protobufjs/path": "1.1.2",
+				"@protobufjs/pool": "1.1.0",
+				"@protobufjs/utf8": "1.1.0",
+				"@types/long": "3.0.32",
+				"@types/node": "7.0.4",
+				"long": "3.2.0"
+			}
+		},
+		"proxyquire": {
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+			"integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+			"requires": {
+				"fill-keys": "1.0.2",
+				"module-not-found-error": "1.0.1",
+				"resolve": "1.1.7"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.3",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "0.1.15"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"requires": {
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"requires": {
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
+		},
+		"requizzle": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+			"integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+			"integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"samsam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"sinon": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
+			"integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.2.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.3.2",
+				"nise": "1.2.5",
+				"supports-color": "5.2.0",
+				"type-detect": "4.0.8"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+					"dev": true
+				}
+			}
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+			"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"stream-to-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+			"requires": {
+				"promise-polyfill": "1.1.6"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"symbol": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+			"dev": true
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.1",
+				"lodash": "4.17.5",
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			}
+		},
+		"taffydb": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+			"dev": true
+		},
+		"tar-fs": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+			"requires": {
+				"chownr": "1.0.1",
+				"mkdirp": "0.5.1",
+				"pump": "1.0.3",
+				"tar-stream": "1.5.5"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"requires": {
+				"bl": "1.2.1",
+				"end-of-stream": "1.4.1",
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+				}
+			}
+		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"thenify": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+			"integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+			"requires": {
+				"any-promise": "1.3.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+			"requires": {
+				"thenify": "3.2.1"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmp-promise": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"tmp": "0.0.33"
+			}
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"requires": {
+				"punycode": "1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
+			}
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"dev": true
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true,
+					"optional": true
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"underscore": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+		},
+		"underscore-contrib": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+			"integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"uri-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"requires": {
+				"punycode": "2.1.0"
+			}
+		},
+		"utf8-bytes": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+			"integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.3",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.4",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"first-chunk-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-bom-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+					"dev": true,
+					"requires": {
+						"first-chunk-stream": "1.0.0",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vm2": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+			"integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg=="
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"winston": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+			"integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+			"requires": {
+				"async": "1.0.0",
+				"colors": "1.0.3",
+				"cycle": "1.0.3",
+				"eyes": "0.1.8",
+				"isstream": "0.1.2",
+				"stack-trace": "0.0.10"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				}
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
+		},
+		"xmlcreate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+			"dev": true
+		},
+		"xregexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"requires": {
+				"camelcase": "4.1.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "7.0.0"
+			}
+		},
+		"yargs-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"requires": {
+				"camelcase": "4.1.0"
+			}
 		}
 	}
 }

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cicero-core",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Cicero Core - implementation of Accord Protocol Template Specification",
   "engines": {
     "node": ">=8",

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -66,7 +66,8 @@
     "tar-stream": "^1.5.5",
     "tmp-promise": "^1.0.4",
     "winston": "^2.3.1",
-    "xregexp": "^4.0.0"
+    "xregexp": "^4.0.0",
+    "jura-compiler": "^0.0.11"
   },
   "license-check-config": {
     "src": [

--- a/packages/cicero-engine/CHANGELOG.md
+++ b/packages/cicero-engine/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package cicero-engine
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/packages/cicero-engine/package-lock.json
+++ b/packages/cicero-engine/package-lock.json
@@ -1,11 +1,6023 @@
 {
-	"requires": true,
+	"name": "cicero-engine",
+	"version": "0.2.44",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+			"integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/inquire": "1.1.0"
+			}
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+		},
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"dev": true,
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"@types/long": {
+			"version": "3.0.32",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+			"optional": true
+		},
+		"@types/node": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+			"integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs="
+		},
+		"abbrev": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
+			}
+		},
+		"ajv-keywords": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+			"integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+			"dev": true
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"axios": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"requires": {
+				"follow-redirects": "1.4.1",
+				"is-buffer": "1.1.6"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				}
+			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.19",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+			"dev": true
+		},
+		"browserfs": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+			"integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+			"requires": {
+				"async": "2.6.0",
+				"pako": "1.0.6"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"requires": {
+				"pako": "0.2.9"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				}
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+		},
+		"catharsis": {
+			"version": "0.8.9",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
+			"integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+			"dev": true,
+			"requires": {
+				"underscore-contrib": "0.3.0"
+			}
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chai": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"dev": true,
+			"requires": {
+				"assertion-error": "1.1.0",
+				"deep-eql": "0.1.3",
+				"type-detect": "1.0.0"
+			}
+		},
+		"chai-as-promised": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+			"integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+			"dev": true,
+			"requires": {
+				"check-error": "1.0.2"
+			}
+		},
+		"chai-things": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+			"integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+			"integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
+		"chardet": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+		},
+		"cicero-core": {
+			"version": "0.2.44",
+			"resolved": "https://registry.npmjs.org/cicero-core/-/cicero-core-0.2.44.tgz",
+			"integrity": "sha512-HMURh2X6c7di8pNT+Bxldl/C2J0ZQw6b6qSDALUbJ6l8VvbW/6Ml7L1gCGsRMiid34rL746W/zO8fA88phtxKQ==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"config": "1.29.4",
+				"debug": "2.6.9",
+				"glob": "7.1.2",
+				"gunzip-maybe": "1.4.1",
+				"ietf-language-tag-regex": "0.0.5",
+				"jszip": "3.1.5",
+				"minimatch": "3.0.4",
+				"moment": "2.20.1",
+				"moo": "0.4.3",
+				"nearley": "2.11.1",
+				"request-promise-native": "1.0.5",
+				"stream-to-string": "1.1.0",
+				"streamifier": "0.1.1",
+				"tar-fs": "1.16.0",
+				"tar-stream": "1.5.5",
+				"tmp-promise": "1.0.4",
+				"winston": "2.4.0",
+				"xregexp": "4.1.1"
+			}
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
+		},
+		"colors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"comment-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+			"integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"composer-common": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.17.4.tgz",
+			"integrity": "sha512-/L6qSq9XbbEbQGvcR6qBd51Eezixt4R9MLJ50ZKUeoW2RzxFVLeHozwXuTsooXVAC3/PCyTE711MmcNNRnNT8Q==",
+			"requires": {
+				"acorn": "5.1.2",
+				"axios": "0.17.1",
+				"browserfs": "1.1.0",
+				"commander": "2.9.0",
+				"comment-parser": "0.4.0",
+				"config": "1.24.0",
+				"debug": "2.6.2",
+				"doctrine": "2.0.0",
+				"esprima": "3.1.2",
+				"fs-promise": "1.0.0",
+				"homedir": "0.6.0",
+				"js-yaml": "3.10.0",
+				"jszip": "3.1.3",
+				"left-pad": "1.1.3",
+				"lorem-ipsum": "1.0.4",
+				"minimatch": "3.0.3",
+				"mkdirp": "0.5.1",
+				"node-plantuml": "0.5.0",
+				"protobufjs": "6.6.3",
+				"proxyquire": "1.7.11",
+				"rimraf": "2.5.4",
+				"semver": "5.3.0",
+				"sprintf-js": "1.0.3",
+				"temp": "0.8.3",
+				"thenify": "3.2.1",
+				"thenify-all": "1.6.0",
+				"uri-js": "3.0.2",
+				"uuid": "3.0.1",
+				"winston": "2.3.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"config": {
+					"version": "1.24.0",
+					"resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+					"integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+					"requires": {
+						"json5": "0.4.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+					"integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+					"requires": {
+						"ms": "0.7.2"
+					}
+				},
+				"jszip": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+					"integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+					"requires": {
+						"core-js": "2.3.0",
+						"es6-promise": "3.0.2",
+						"lie": "3.1.1",
+						"pako": "1.0.6",
+						"readable-stream": "2.0.6"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"ms": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"winston": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+					"integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+					"requires": {
+						"async": "1.0.0",
+						"colors": "1.0.3",
+						"cycle": "1.0.3",
+						"eyes": "0.1.8",
+						"isstream": "0.1.2",
+						"stack-trace": "0.0.10"
+					}
+				}
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"typedarray": "0.0.6"
+			}
+		},
+		"config": {
+			"version": "1.29.4",
+			"resolved": "https://registry.npmjs.org/config/-/config-1.29.4.tgz",
+			"integrity": "sha1-G0J1LthrNj/EAllgVp/XSXiGKpI=",
+			"requires": {
+				"json5": "0.4.0",
+				"os-homedir": "1.0.2"
+			}
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+			"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+			"dev": true
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-eql": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"dev": true,
+			"requires": {
+				"type-detect": "0.1.1"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+					"dev": true
+				}
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.5.4"
+			}
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+			"dev": true
+		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+		},
+		"doctrine": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"requires": {
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
+			}
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+			"integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.4",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
+			"requires": {
+				"esprima": "2.7.3",
+				"estraverse": "1.9.3",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.2.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
+				}
+			}
+		},
+		"eslint": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.1.tgz",
+			"integrity": "sha512-gPSfpSRCHre1GLxGmO68tZNxOlL2y7xBd95VcLD+Eo4S2js31YoMum3CAQIOaxY24hqYOMksMvW38xuuWKQTgw==",
+			"dev": true,
+			"requires": {
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.1",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.3",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.3.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.3.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.3",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"dev": true,
+					"requires": {
+						"esutils": "2.0.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"dev": true
+		},
+		"espree": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+			"integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.4.1",
+				"acorn-jsx": "3.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+					"integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+			"integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ="
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			}
+		},
+		"execa": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"external-editor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+			"dev": true,
+			"requires": {
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				}
+			}
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"dev": true,
+			"requires": {
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "1.0.1",
+				"merge-descriptors": "1.0.1"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"requires": {
+				"locate-path": "2.0.0"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"jsonfile": "2.4.0",
+				"klaw": "1.3.1"
+			}
+		},
+		"fs-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+			"integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+			"requires": {
+				"any-promise": "1.3.0",
+				"fs-extra": "1.0.0",
+				"mz": "2.7.0",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"globals": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+			"integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+			"dev": true
+		},
+		"globby": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+			"dev": true
+		},
+		"gulp-license-check": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
+			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
+			"dev": true,
+			"requires": {
+				"event-stream": "3.3.4",
+				"gulp-util": "3.0.8",
+				"through2": "2.0.3",
+				"vinyl-file": "2.0.0"
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.2",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
+			"requires": {
+				"glogg": "1.0.1"
+			}
+		},
+		"gunzip-maybe": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+			"integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+			"requires": {
+				"browserify-zlib": "0.1.4",
+				"is-deflate": "1.0.0",
+				"is-gzip": "1.0.0",
+				"peek-stream": "1.1.2",
+				"pumpify": "1.4.0",
+				"through2": "2.0.3"
+			}
+		},
+		"handlebars": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"dev": true,
+			"requires": {
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"dev": true
+		},
+		"homedir": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+			"integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4="
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"iconv-lite": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+			"dev": true
+		},
+		"ietf-language-tag-regex": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/ietf-language-tag-regex/-/ietf-language-tag-regex-0.0.5.tgz",
+			"integrity": "sha1-gRM62z0ckpuP8fRyVEkK7no0Ys4=",
+			"requires": {
+				"xregexp": "3.2.0"
+			},
+			"dependencies": {
+				"xregexp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+					"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+				}
+			}
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"inquirer": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.1",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.5",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-deflate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+			"integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9",
+				"async": "1.5.2",
+				"escodegen": "1.8.1",
+				"esprima": "2.7.3",
+				"glob": "5.0.15",
+				"handlebars": "4.0.11",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"once": "1.4.0",
+				"resolve": "1.1.7",
+				"supports-color": "3.2.3",
+				"which": "1.3.0",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+				}
+			}
+		},
+		"js2xmlparser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
+			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+			"dev": true,
+			"requires": {
+				"xmlcreate": "1.0.2"
+			}
+		},
+		"jsdoc": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
+			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+			"dev": true,
+			"requires": {
+				"babylon": "7.0.0-beta.19",
+				"bluebird": "3.5.1",
+				"catharsis": "0.8.9",
+				"escape-string-regexp": "1.0.5",
+				"js2xmlparser": "3.0.0",
+				"klaw": "2.0.0",
+				"marked": "0.3.16",
+				"mkdirp": "0.5.1",
+				"requizzle": "0.2.1",
+				"strip-json-comments": "2.0.1",
+				"taffydb": "2.6.2",
+				"underscore": "1.8.3"
+			},
+			"dependencies": {
+				"klaw": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
+					"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				},
+				"underscore": {
+					"version": "1.8.3",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+					"dev": true
+				}
+			}
+		},
+		"json-schema-traverse": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+			"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jszip": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+			"integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+			"requires": {
+				"core-js": "2.3.0",
+				"es6-promise": "3.0.2",
+				"lie": "3.1.1",
+				"pako": "1.0.6",
+				"readable-stream": "2.0.6"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"jura-compiler": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/jura-compiler/-/jura-compiler-0.0.11.tgz",
+			"integrity": "sha512-+ViM6YP09aFIvqSfK360aNz5p/N1fzMf8ciuCLD3DwrthiAQ/6Z/lBDgxMtBZKyvCCfI8xv7sgPFsLgsVSKFsw==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"moment": "2.20.1",
+				"nearley": "2.11.1",
+				"pegjs": "0.10.0",
+				"vm2": "3.5.2",
+				"yargs": "9.0.1"
+			}
+		},
+		"just-extend": {
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"optional": true
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"requires": {
+				"invert-kv": "1.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+			"integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"license-check": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
+			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
+			"dev": true,
+			"requires": {
+				"gulp-license-check": "1.2.1",
+				"gulp-util": "3.0.8",
+				"istanbul": "0.4.5",
+				"pkg-conf": "1.1.3",
+				"vinyl-fs": "2.4.4"
+			}
+		},
+		"lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+			"requires": {
+				"immediate": "3.0.6"
+			}
+		},
+		"load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"strip-bom": "3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.5",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._basecreate": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+			"dev": true
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
+		},
+		"lodash.create": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+			"dev": true,
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._basecreate": "3.0.3",
+				"lodash._isiterateecall": "3.0.9"
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lolex": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+			"dev": true
+		},
+		"long": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"optional": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true
+		},
+		"lorem-ipsum": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+			"integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+			"requires": {
+				"optimist": "0.3.7"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
+		"marked": {
+			"version": "0.3.16",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.16.tgz",
+			"integrity": "sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q==",
+			"dev": true
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "2.3.4"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			}
+		},
+		"mocha": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"dev": true,
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.8",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
+				"growl": "1.9.2",
+				"he": "1.1.1",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "3.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"mockery": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+			"integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+			"dev": true
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+		},
 		"moment": {
 			"version": "2.20.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
 			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+		},
+		"moo": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
+		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"requires": {
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"nearley": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
+			"integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+			"requires": {
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
+				"randexp": "0.4.6",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+				}
+			}
+		},
+		"nise": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.2.6.tgz",
+			"integrity": "sha512-ewMXDEflamPfDbh7y08tbrJCAiN87SEz388s2cG4ODYnA+ge6QB8pvjo+Pkv9844qMB+NPE9O8tMyIEle0vyew==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "1.1.27",
+				"lolex": "2.3.2",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
+			}
+		},
+		"node-nailgun-client": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+			"integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-nailgun-server": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+			"integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+			"requires": {
+				"commander": "2.9.0"
+			}
+		},
+		"node-plantuml": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+			"integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+			"requires": {
+				"commander": "2.9.0",
+				"node-nailgun-client": "0.1.0",
+				"node-nailgun-server": "0.1.3",
+				"plantuml-encoder": "1.2.5"
+			}
+		},
+		"nomnom": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"requires": {
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+					"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+				}
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.9"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.3.0",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nyc": {
+			"version": "11.4.1",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+			"integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+			"dev": true,
+			"requires": {
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.1.1",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.9.1",
+				"istanbul-lib-report": "1.1.2",
+				"istanbul-lib-source-maps": "1.2.2",
+				"istanbul-reports": "1.1.3",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.0.4",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.1.1",
+				"yargs": "10.0.3",
+				"yargs-parser": "8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true,
+					"dev": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.4",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"core-js": "2.5.3",
+						"regenerator-runtime": "0.11.1"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.2",
+						"lodash": "4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.4",
+						"to-fast-properties": "1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.8",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true,
+					"dev": true
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"bundled": true,
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "4.1.1",
+						"which": "1.3.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"strip-bom": "2.0.0"
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"lru-cache": "4.1.1",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true,
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true,
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"amdefine": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"hosted-git-info": {
+					"version": "2.5.0",
+					"bundled": true,
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"invariant": {
+					"version": "2.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"append-transform": "0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.9.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"babel-generator": "6.26.0",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"semver": "5.4.1"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.1.1",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"handlebars": "4.0.11"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.4",
+					"bundled": true,
+					"dev": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"mimic-fn": "1.1.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "2.5.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.4.1",
+						"validate-npm-package-license": "3.0.1"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "2.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "1.1.0"
+					}
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true,
+					"dev": true
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true,
+					"dev": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.4.1",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true,
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true,
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-license-ids": "1.2.2"
+					}
+				},
+				"spdx-expression-parse": {
+					"version": "1.0.4",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-license-ids": {
+					"version": "1.2.2",
+					"bundled": true,
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"micromatch": "2.3.11",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-correct": "1.0.2",
+						"spdx-expression-parse": "1.0.4"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.0.0"
+					},
+					"dependencies": {
+						"cliui": {
+							"version": "3.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wrap-ansi": "2.1.0"
+							},
+							"dependencies": {
+								"string-width": {
+									"version": "1.0.2",
+									"bundled": true,
+									"dev": true,
+									"requires": {
+										"code-point-at": "1.1.0",
+										"is-fullwidth-code-point": "1.0.0",
+										"strip-ansi": "3.0.1"
+									}
+								}
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "1.2.0"
+			}
+		},
+		"optimist": {
+			"version": "0.3.7",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+			"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+			"requires": {
+				"wordwrap": "0.0.3"
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.4"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"requires": {
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+			"requires": {
+				"p-try": "1.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"requires": {
+				"p-limit": "1.2.0"
+			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
+		},
+		"path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"peek-stream": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
+			"integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
+			"requires": {
+				"duplexify": "3.5.3",
+				"through2": "2.0.3"
+			}
+		},
+		"pegjs": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+			"dev": true,
+			"requires": {
+				"find-up": "1.1.2",
+				"load-json-file": "1.1.0",
+				"object-assign": "4.1.1",
+				"symbol": "0.2.3"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"plantuml-encoder": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.5.tgz",
+			"integrity": "sha512-viV7Sz+BJNX/sC3iyebh2VfLyAZKuu3+JuBs2ISms8+zoTGwPqwk3/WEDw/zROmGAJ/xD4sNd8zsBw/YmTo7ng==",
+			"requires": {
+				"pako": "1.0.3",
+				"utf8-bytes": "0.0.1"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+					"integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8="
+				}
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+			"dev": true
+		},
+		"promise-polyfill": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+			"integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+		},
+		"protobufjs": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+			"integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/base64": "1.1.2",
+				"@protobufjs/codegen": "1.0.8",
+				"@protobufjs/eventemitter": "1.1.0",
+				"@protobufjs/fetch": "1.1.0",
+				"@protobufjs/inquire": "1.1.0",
+				"@protobufjs/path": "1.1.2",
+				"@protobufjs/pool": "1.1.0",
+				"@protobufjs/utf8": "1.1.0",
+				"@types/long": "3.0.32",
+				"@types/node": "7.0.4",
+				"long": "3.2.0"
+			}
+		},
+		"proxyquire": {
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+			"integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+			"requires": {
+				"fill-keys": "1.0.2",
+				"module-not-found-error": "1.0.1",
+				"resolve": "1.1.7"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.3",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "0.1.15"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"requires": {
+				"load-json-file": "2.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "2.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"requires": {
+				"find-up": "2.1.0",
+				"read-pkg": "2.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+			"integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
+		},
+		"requizzle": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+			"integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"rimraf": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+			"integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+			"requires": {
+				"glob": "7.1.2"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+			"dev": true
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"dev": true,
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"samsam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+			"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"sinon": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
+			"integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.2.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.3.2",
+				"nise": "1.2.6",
+				"supports-color": "5.2.0",
+				"type-detect": "4.0.8"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+					"integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+					"dev": true
+				}
+			}
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+			"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"stream-to-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+			"requires": {
+				"promise-polyfill": "1.1.6"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"dev": true,
+			"requires": {
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				}
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"symbol": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+			"dev": true
+		},
+		"table": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+			"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+			"dev": true,
+			"requires": {
+				"ajv": "6.2.0",
+				"ajv-keywords": "3.1.0",
+				"chalk": "2.3.1",
+				"lodash": "4.17.5",
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+					"integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
+					}
+				}
+			}
+		},
+		"taffydb": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+			"dev": true
+		},
+		"tar-fs": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+			"requires": {
+				"chownr": "1.0.1",
+				"mkdirp": "0.5.1",
+				"pump": "1.0.3",
+				"tar-stream": "1.5.5"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"requires": {
+				"bl": "1.2.1",
+				"end-of-stream": "1.4.1",
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+				}
+			}
+		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+			"dev": true
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"thenify": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+			"integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+			"requires": {
+				"any-promise": "1.3.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+			"requires": {
+				"thenify": "3.2.1"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "2.3.4",
+				"xtend": "4.0.1"
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmp-promise": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"tmp": "0.0.33"
+			}
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+			"requires": {
+				"punycode": "1.4.1"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				}
+			}
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+			"dev": true
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"source-map": "0.5.7",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true,
+					"optional": true
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+					"dev": true,
+					"optional": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
+		"underscore": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+		},
+		"underscore-contrib": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+			"integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+			"dev": true,
+			"requires": {
+				"underscore": "1.6.0"
+			},
+			"dependencies": {
+				"underscore": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+					"dev": true
+				}
+			}
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"uri-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"requires": {
+				"punycode": "2.1.0"
+			}
+		},
+		"utf8-bytes": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+			"integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"dev": true,
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
+			"requires": {
+				"duplexify": "3.5.3",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.4",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"first-chunk-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-bom-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+					"dev": true,
+					"requires": {
+						"first-chunk-stream": "1.0.0",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vm2": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+			"integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg=="
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"optional": true
+		},
+		"winston": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+			"integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+			"requires": {
+				"async": "1.0.0",
+				"colors": "1.0.3",
+				"cycle": "1.0.3",
+				"eyes": "0.1.8",
+				"isstream": "0.1.2",
+				"stack-trace": "0.0.10"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				}
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
+		},
+		"xmlcreate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+			"dev": true
+		},
+		"xregexp": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.1.1.tgz",
+			"integrity": "sha512-QJ1gfSUV7kEOLfpKFCjBJRnfPErUzkNKFMso4kDSmGpp3x6ZgkyKf74inxI7PnnQCFYq5TqYJCd7DrgDN8Q05A=="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"requires": {
+				"camelcase": "4.1.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "7.0.0"
+			}
+		},
+		"yargs-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"requires": {
+				"camelcase": "4.1.0"
+			}
 		}
 	}
 }

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cicero-engine",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Cicero Engine - Node.js VM based implementation of Accord Protcol Template Specification execution",
   "engines": {
     "node": ">=8",
@@ -44,7 +44,7 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.43",
+    "cicero-core": "^0.2.44",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -51,7 +51,8 @@
     "moment": "^2.20.1",
     "nearley": "^2.11.0",
     "vm2": "^3.5.0",
-    "winston": "^2.3.1"
+    "winston": "^2.3.1",
+    "jura-compiler": "^0.0.11"
   },
   "license-check-config": {
     "src": [

--- a/packages/cicero-engine/test/data/helloworld/README.md
+++ b/packages/cicero-engine/test/data/helloworld/README.md
@@ -1,0 +1,106 @@
+# Hello World 
+
+This is a smart legal clause conforms that to the [Accord Protocol Template Specification](https://docs.google.com/document/d/1UacA_r2KGcBA2D4voDgGE8jqid-Uh4Dt09AE-shBKR0), the protocol is managed by the open-source community of the [Accord Project](https://accordproject.org). The clause can be parsed and executed by the [Cicero](https://github.com/accordproject/cicero) engine.
+
+## Description
+
+> This is the Hello World of Accord Protocol Templates. Executing the clause will simply echo back the text that occurs after the string `Hello` prepended to text that is passed in the request.
+
+This clause contains:
+- *Some sample Clause Text* - [sample.txt](sample.txt)
+- *A template* - [grammar/template.tem](grammar/template.tem)
+- *A data model* - [models/model.cto](models/model.cto)
+- *Contact logic* (in JavaScript) - [logic/logic.js](lib/logic.js)
+
+## Running this clause
+
+### On your own machine
+
+1. [Download the Cicero template library](https://github.com/accordproject/cicero-template-library/archive/master.zip)
+
+2. Unzip the library with your favourite tool
+
+3. Then from the command-line, change the current directory to the folder containing this README.md file.
+```
+cd helloworld
+```
+4. With the [Cicero command-line tool](https://github.com/accordproject/cicero#installation):
+```
+cicero execute --template ./ --dsl ./sample --data ./data.json
+```
+> Note, all of the command-line flags (like `--template`) are optional.
+
+Alternatively you can use the simpler command below if you want to use all of the default files.
+```
+cicero execute
+```
+
+You should see the following output in your terminal:
+```bash
+mattmbp:helloworld matt$ cicero execute
+11:01:15 - info: Logging initialized. 2018-02-18T11:01:15.771Z
+11:01:16 - info: Using current directory as template folder
+11:01:16 - info: Loading a default sample.txt file.
+11:01:16 - info: Loading a default data.json file.
+11:01:16 - info: {"clause":"helloworld@0.0.5-3119b65d48818b038883b0846738d34a61df5ac895093eb88003f07c96ee39c7","request":{"$class":"org.accordproject.helloworld.Request","input":"Accord Project"},"response":{"$class":"org.accordproject.helloworld.Response","output":"Hello Fred Blogs Accord Project","transactionId":"1831144a-a329-4c4e-83f4-c50c238d561c","timestamp":"2018-02-18T11:01:16.572Z"}}
+```
+
+### Sample Payload Data
+
+
+Request, as in [data.json](https://github.com/accordproject/cicero-template-library/blob/master/helloworld/data.json)
+```json
+{
+    "$class": "org.accordproject.helloworld.Request",
+    "input": "Accord Project"
+}
+
+```
+
+For the request above, you should see the following response:
+```json
+{
+    "$class":"org.accordproject.helloworld.Response",
+    "output":"Hello Fred Blogs Accord Project",
+    "transactionId":"1831144a-a329-4c4e-83f4-c50c238d561c",
+    "timestamp":"2018-02-18T11:01:16.572Z"
+}
+```
+
+
+## Testing this clause
+
+This clause comes with an automated test that ensures that it executes correctly under different conditions. To test the clause, complete the following steps.
+
+You need npm and node to test a clause. You can download both from [here](https://nodejs.org/).
+
+> This clause was tested with Node v8.9.3 and NPM v5.6.0
+
+From the `helloworld` directory.
+
+1. Install all of the dependencies.
+```
+npm install
+```
+
+2. Run the tests
+```
+npm test
+```
+If successful, you should see the following output
+```
+mattmbp:helloworld matt$ npm test
+
+> helloworld@0.0.5 test /Users/matt/dev/accordproject/cicero-template-library/helloworld
+> mocha
+
+10:59:43 - info: Logging initialized. 2018-02-18T10:59:43.781Z
+
+
+  Logic
+    #Hello
+      ✓ should produce correct result
+
+
+  1 passing (217ms)
+```

--- a/packages/cicero-engine/test/data/helloworld/data.json
+++ b/packages/cicero-engine/test/data/helloworld/data.json
@@ -1,0 +1,4 @@
+{
+    "$class": "org.accordproject.helloworld.Request",
+    "input": "Accord Project"
+}

--- a/packages/cicero-engine/test/data/helloworld/grammar/template.tem
+++ b/packages/cicero-engine/test/data/helloworld/grammar/template.tem
@@ -1,0 +1,2 @@
+Name of the person to greet: [{name}].
+Thank you!

--- a/packages/cicero-engine/test/data/helloworld/lib/logic.jura
+++ b/packages/cicero-engine/test/data/helloworld/lib/logic.jura
@@ -1,0 +1,8 @@
+package org.accordproject.helloworld
+
+contract HelloWorld over TemplateModel {
+   // Simple Clause
+   clause helloworld(request Request) Response {
+       new Response{ output: "Hello " + this.name + " (" + request.input +")" }
+  }
+}

--- a/packages/cicero-engine/test/data/helloworld/models/model.cto
+++ b/packages/cicero-engine/test/data/helloworld/models/model.cto
@@ -1,0 +1,20 @@
+namespace org.accordproject.helloworld
+
+transaction Request {
+  o String input
+}
+
+transaction Response {
+  o String output
+}
+
+/**
+ * The template model
+ */
+@AccordTemplateModel("helloworld")
+concept TemplateModel {
+  /**
+   * The name for the clause
+   */
+  o String name
+}

--- a/packages/cicero-engine/test/data/helloworld/package-lock.json
+++ b/packages/cicero-engine/test/data/helloworld/package-lock.json
@@ -1,0 +1,1431 @@
+{
+    "name": "helloworld",
+    "version": "0.0.5",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+            "dev": true
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "dev": true
+        },
+        "@protobufjs/codegen": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+            "integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0=",
+            "dev": true
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+            "dev": true
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "dev": true,
+            "requires": {
+                "@protobufjs/aspromise": "1.1.2",
+                "@protobufjs/inquire": "1.1.0"
+            }
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+            "dev": true
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+            "dev": true
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+            "dev": true
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+            "dev": true
+        },
+        "@types/long": {
+            "version": "3.0.32",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+            "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+            "dev": true,
+            "optional": true
+        },
+        "@types/node": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+            "integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+            "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+            "dev": true
+        },
+        "any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+            "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "bluebird": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "browserfs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+            "integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "pako": "1.0.6"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+            "dev": true,
+            "requires": {
+                "pako": "0.2.9"
+            },
+            "dependencies": {
+                "pako": {
+                    "version": "0.2.9",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+                    "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+                    "dev": true
+                }
+            }
+        },
+        "chai": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+            "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.0.2",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.5"
+            }
+        },
+        "chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "requires": {
+                "check-error": "1.0.2"
+            }
+        },
+        "chai-things": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+            "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+            "dev": true
+        },
+        "cicero-core": {
+            "version": "0.2.24",
+            "resolved": "https://registry.npmjs.org/cicero-core/-/cicero-core-0.2.24.tgz",
+            "integrity": "sha512-ws9lJ+LoBJUhrEIr6rfJ6TiQVjEhxgMwDq/Wt/RFOBT+8Jlz+X02MAvdy8DCr0vBuE3I1DuACc7z3hxgtzRnsg==",
+            "dev": true,
+            "requires": {
+                "composer-common": "0.16.2",
+                "config": "1.28.1",
+                "debug": "2.6.9",
+                "gunzip-maybe": "1.4.1",
+                "jszip": "3.1.5",
+                "minimatch": "3.0.4",
+                "moment": "2.20.1",
+                "moo": "0.4.3",
+                "nearley": "2.11.0",
+                "request-promise-native": "1.0.5",
+                "stream-to-string": "1.1.0",
+                "streamifier": "0.1.1",
+                "tar-fs": "1.16.0",
+                "tar-stream": "1.5.5",
+                "tmp-promise": "1.0.4",
+                "winston": "2.4.0"
+            }
+        },
+        "cicero-engine": {
+            "version": "0.2.24",
+            "resolved": "https://registry.npmjs.org/cicero-engine/-/cicero-engine-0.2.24.tgz",
+            "integrity": "sha512-PKvMbExdERAjbduvSgSqDWTuYiKu9+IE95yryTsvcVl9+mslMRO/O8+aBxPYkq2f5mV0gIkckKRoPIDsYX4FAg==",
+            "dev": true,
+            "requires": {
+                "cicero-core": "0.2.24",
+                "composer-common": "0.16.2",
+                "config": "1.28.1",
+                "debug": "2.6.9",
+                "moment": "2.20.1",
+                "nearley": "2.11.0",
+                "vm2": "3.5.2",
+                "winston": "2.4.0"
+            }
+        },
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true,
+            "requires": {
+                "graceful-readlink": "1.0.1"
+            }
+        },
+        "comment-parser": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+            "integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "composer-common": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.16.2.tgz",
+            "integrity": "sha512-qryn6aDvq1iAxgQq+QVA8p617RyCM8tWVv2NLxrpVnlHTR9N09psErYsaksudEbtG4hSL5l0lS+gTNVpqXGV7A==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.1.2",
+                "browserfs": "1.1.0",
+                "commander": "2.9.0",
+                "comment-parser": "0.4.0",
+                "config": "1.24.0",
+                "debug": "2.6.2",
+                "doctrine": "2.0.0",
+                "esprima": "3.1.2",
+                "fs-promise": "1.0.0",
+                "homedir": "0.6.0",
+                "jszip": "3.1.3",
+                "left-pad": "1.1.3",
+                "lorem-ipsum": "1.0.4",
+                "minimatch": "3.0.3",
+                "mkdirp": "0.5.1",
+                "node-plantuml": "0.5.0",
+                "protobufjs": "6.6.3",
+                "proxyquire": "1.7.11",
+                "rimraf": "2.5.4",
+                "semver": "5.3.0",
+                "sprintf-js": "1.0.3",
+                "temp": "0.8.3",
+                "thenify": "3.2.1",
+                "thenify-all": "1.6.0",
+                "uri-js": "3.0.2",
+                "uuid": "3.0.1",
+                "winston": "2.3.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true
+                },
+                "config": {
+                    "version": "1.24.0",
+                    "resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+                    "integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+                    "dev": true,
+                    "requires": {
+                        "json5": "0.4.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+                    "integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "0.7.2"
+                    }
+                },
+                "jszip": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+                    "integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+                    "dev": true,
+                    "requires": {
+                        "core-js": "2.3.0",
+                        "es6-promise": "3.0.2",
+                        "lie": "3.1.1",
+                        "pako": "1.0.6",
+                        "readable-stream": "2.0.6"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                    "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "winston": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+                    "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+                    "dev": true,
+                    "requires": {
+                        "async": "1.0.0",
+                        "colors": "1.0.3",
+                        "cycle": "1.0.3",
+                        "eyes": "0.1.8",
+                        "isstream": "0.1.2",
+                        "stack-trace": "0.0.10"
+                    }
+                }
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "config": {
+            "version": "1.28.1",
+            "resolved": "https://registry.npmjs.org/config/-/config-1.28.1.tgz",
+            "integrity": "sha1-diXSoeTJDxMdinM0eYLZPDhzKC0=",
+            "dev": true,
+            "requires": {
+                "json5": "0.4.0",
+                "os-homedir": "1.0.2"
+            }
+        },
+        "core-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.5"
+            }
+        },
+        "diff": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "dev": true
+        },
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+            }
+        },
+        "duplexify": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+            "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "es6-promise": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+            "integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+            "dev": true
+        },
+        "fill-keys": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+            "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+            "dev": true,
+            "requires": {
+                "is-object": "1.0.1",
+                "merge-descriptors": "1.0.1"
+            }
+        },
+        "fs-extra": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "2.4.0",
+                "klaw": "1.3.1"
+            }
+        },
+        "fs-promise": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+            "integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0",
+                "fs-extra": "1.0.0",
+                "mz": "2.7.0",
+                "thenify-all": "1.6.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "dev": true
+        },
+        "gunzip-maybe": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+            "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+            "dev": true,
+            "requires": {
+                "browserify-zlib": "0.1.4",
+                "is-deflate": "1.0.0",
+                "is-gzip": "1.0.0",
+                "peek-stream": "1.1.2",
+                "pumpify": "1.3.5",
+                "through2": "2.0.3"
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "homedir": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+            "integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4=",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is-deflate": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+            "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=",
+            "dev": true
+        },
+        "is-gzip": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+            "dev": true
+        },
+        "is-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+            "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "jszip": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "dev": true,
+            "requires": {
+                "core-js": "2.3.0",
+                "es6-promise": "3.0.2",
+                "lie": "3.1.1",
+                "pako": "1.0.6",
+                "readable-stream": "2.0.6"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "left-pad": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+            "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=",
+            "dev": true
+        },
+        "lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "dev": true,
+            "requires": {
+                "immediate": "3.0.6"
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+            "dev": true,
+            "optional": true
+        },
+        "lorem-ipsum": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+            "integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+            "dev": true,
+            "requires": {
+                "optimist": "0.3.7"
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+            "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "4.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "module-not-found-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+            "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+            "dev": true
+        },
+        "moment": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+            "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+            "dev": true
+        },
+        "moo": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+            "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+            "dev": true
+        },
+        "ms": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+            "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+            "dev": true
+        },
+        "mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0",
+                "object-assign": "4.1.1",
+                "thenify-all": "1.6.0"
+            }
+        },
+        "nearley": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.0.tgz",
+            "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
+            "dev": true,
+            "requires": {
+                "nomnom": "1.6.2",
+                "railroad-diagrams": "1.0.0",
+                "randexp": "0.4.6"
+            }
+        },
+        "node-nailgun-client": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+            "integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0"
+            }
+        },
+        "node-nailgun-server": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+            "integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0"
+            }
+        },
+        "node-plantuml": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+            "integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0",
+                "node-nailgun-client": "0.1.0",
+                "node-nailgun-server": "0.1.3",
+                "plantuml-encoder": "1.2.4"
+            }
+        },
+        "nomnom": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+            "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+            "dev": true,
+            "requires": {
+                "colors": "0.5.1",
+                "underscore": "1.4.4"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                    "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+                    "dev": true
+                }
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optimist": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+            "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+            "dev": true,
+            "requires": {
+                "wordwrap": "0.0.3"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "peek-stream": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
+            "integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.1",
+                "through2": "2.0.3"
+            }
+        },
+        "plantuml-encoder": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.4.tgz",
+            "integrity": "sha1-XwBW98BL12ru9CC/zd7zOen0QIE=",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.3",
+                "utf8-bytes": "0.0.1"
+            },
+            "dependencies": {
+                "pako": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+                    "integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8=",
+                    "dev": true
+                }
+            }
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "promise-polyfill": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+            "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
+            "dev": true
+        },
+        "protobufjs": {
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+            "integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+            "dev": true,
+            "requires": {
+                "@protobufjs/aspromise": "1.1.2",
+                "@protobufjs/base64": "1.1.2",
+                "@protobufjs/codegen": "1.0.8",
+                "@protobufjs/eventemitter": "1.1.0",
+                "@protobufjs/fetch": "1.1.0",
+                "@protobufjs/inquire": "1.1.0",
+                "@protobufjs/path": "1.1.2",
+                "@protobufjs/pool": "1.1.0",
+                "@protobufjs/utf8": "1.1.0",
+                "@types/long": "3.0.32",
+                "@types/node": "7.0.4",
+                "long": "3.2.0"
+            }
+        },
+        "proxyquire": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+            "integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+            "dev": true,
+            "requires": {
+                "fill-keys": "1.0.2",
+                "module-not-found-error": "1.0.1",
+                "resolve": "1.1.7"
+            }
+        },
+        "pump": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+            "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.1",
+                "inherits": "2.0.3",
+                "pump": "1.0.3"
+            }
+        },
+        "punycode": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+            "dev": true
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+            "dev": true
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dev": true,
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "0.1.15"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+            }
+        },
+        "resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "stream-to-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+            "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+            "dev": true,
+            "requires": {
+                "promise-polyfill": "1.1.6"
+            }
+        },
+        "streamifier": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "supports-color": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "2.0.0"
+            }
+        },
+        "tar-fs": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+            "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+            "dev": true,
+            "requires": {
+                "chownr": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pump": "1.0.3",
+                "tar-stream": "1.5.5"
+            }
+        },
+        "tar-stream": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "dev": true,
+            "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "temp": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+            "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2",
+                "rimraf": "2.2.8"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.2.8",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
+                }
+            }
+        },
+        "thenify": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+            "integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0"
+            }
+        },
+        "thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+            "dev": true,
+            "requires": {
+                "thenify": "3.2.1"
+            }
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "tmp-promise": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+            "integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.5.1",
+                "tmp": "0.0.33"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "type-detect": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+            "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+            "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            }
+        },
+        "utf8-bytes": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+            "integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+            "dev": true
+        },
+        "vm2": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+            "integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg==",
+            "dev": true
+        },
+        "winston": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+            "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+            "dev": true,
+            "requires": {
+                "async": "1.0.0",
+                "colors": "1.0.3",
+                "cycle": "1.0.3",
+                "eyes": "0.1.8",
+                "isstream": "0.1.2",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true
+                }
+            }
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        }
+    }
+}

--- a/packages/cicero-engine/test/data/helloworld/package.json
+++ b/packages/cicero-engine/test/data/helloworld/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "helloworld",
+    "version": "0.0.5",
+    "description": "This is the Hello World of Accord Protocol Templates. Executing the clause will simply echo back the text that occurs after the string `Hello` prepended to text that is passed in the request.",
+    "engines": {
+        "cicero": "^0.2.28"
+    },
+    "scripts": {
+        "test": "mocha"
+    },
+    "devDependencies": {
+        "chai": "^4.1.2",
+        "chai-as-promised": "^7.1.1",
+        "chai-things": "^0.2.0",
+        "cicero-core": "^0.2.13",
+        "cicero-engine": "^0.2.13",
+        "mocha": "^4.0.1",
+        "moment": "^2.19.2"
+    }
+}

--- a/packages/cicero-engine/test/data/helloworld/sample.txt
+++ b/packages/cicero-engine/test/data/helloworld/sample.txt
@@ -1,0 +1,2 @@
+Name of the person to greet: "Fred Blogs".
+Thank you!

--- a/packages/cicero-engine/test/data/helloworld/test/logic.js
+++ b/packages/cicero-engine/test/data/helloworld/test/logic.js
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Template = require('cicero-core').Template;
+const Clause = require('cicero-core').Clause;
+const Engine = require('cicero-engine').Engine;
+
+const fs = require('fs');
+const path = require('path');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-things'));
+chai.use(require('chai-as-promised'));
+const moment = require('moment');
+
+describe('Logic', () => {
+
+    const rootDir = path.resolve(__dirname, '..');
+    const clauseText = fs.readFileSync(path.resolve(rootDir, 'sample.txt'), 'utf8');
+
+    let template;
+    let clause;
+    let engine;    
+
+    beforeEach( async function() {
+        template = await Template.fromDirectory(rootDir);
+        clause = new Clause(template);
+        clause.parse(clauseText);
+        engine = new Engine();    
+    });
+    
+    describe('#Hello', async function() {
+
+        it('should produce correct result', async function() {
+            const request = {};
+            request.$class = 'org.accordproject.helloworld.Request';
+            request.input = 'World'
+            const result = await engine.execute(clause, request);
+            result.should.not.be.null;
+            result.response.output.should.equal('Hello Fred Blogs World');
+        });
+    });
+});

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty/lib/logic.jura
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty/lib/logic.jura
@@ -1,0 +1,42 @@
+package io.clause.latedeliveryandpenalty
+
+// Imports CTO files
+import org.accordproject.contract.*
+import io.clause.latedeliveryandpenalty.*
+// Date and time library
+import jura.moment.*
+
+/* From template:
+Late Delivery and Penalty. In case of delayed delivery[{" except for Force Majeure cases,":? forceMajeure}] the Seller shall pay to the Buyer for every [{penaltyDuration}] of delay penalty amounting to [{penaltyPercentage}]% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a [{fractionalPart}] is to be considered a full [{fractionalPart}]. The total amount of penalty shall not however, exceed [{capPercentage}]% of the total value of the Equipment involved in late delivery. If the delay is more than [{termination}], the Buyer is entitled to terminate this Contract.
+ */
+
+// Declare a contract over a template model
+contract LateDeliveryAndPenalty over TemplateModel {
+  // Clause checking for late delivery and calculating penalty
+  clause latedeliveryandpenalty(request LateDeliveryAndPenaltyRequest) LateDeliveryAndPenaltyResponse throws Error {
+    // Guard against calling late delivery clause too early
+    let agreed = request.agreedDelivery;
+    guard momentIsBefore(agreed,now()) else {
+      throw Error{ message : "Cannot exercise late delivery before delivery date" }
+    }
+    // Guard against force majeure
+    guard !this.forceMajeure || !request.forceMajeure else {
+      return new LateDeliveryAndPenaltyResponse{
+	penalty: 0,
+	buyerMayTerminate: true
+      }
+    }
+
+    // Calculate the time difference between current date and agreed upon date
+    let diff = momentDiff(now,agreed);
+    // Penalty formula
+    let penalty = (diff / this.penaltyDuration.amount) * this.penaltyPercentage/100 * request.goodsValue;
+    // Penalty may be capped
+    let capped = min([penalty,this.capPercentage * request.goodsValue / 100]);
+    // Return the response with the penalty and termination determination
+    return new LateDeliveryAndPenaltyResponse{
+      penalty: capped,
+      buyerMayTerminate: diff > this.termination.amount
+    }
+  }
+}

--- a/packages/cicero-engine/test/data/volumediscount/README.md
+++ b/packages/cicero-engine/test/data/volumediscount/README.md
@@ -1,0 +1,110 @@
+
+# Volume Discount
+
+This is a smart legal clause conforms that to the [Accord Protocol Template Specification](https://docs.google.com/document/d/1UacA_r2KGcBA2D4voDgGE8jqid-Uh4Dt09AE-shBKR0), the protocol is managed by the open-source community of the [Accord Project](https://accordproject.org). The clause can be parsed and executed by the [Cicero](https://github.com/accordproject/cicero) engine.
+
+## Description
+
+> A sample volume discount clause.
+
+This clause contains:
+- *Sample Clause Text* - [sample.txt](sample.txt)
+- *A template* - [grammar/template.tem](grammar/template.tem)
+- *A data model* - [models/clause.cto](models/clause.cto)
+- *Contact logic* (in JavaScript) - [logic/logic.js](lib/logic.js)
+
+## Running this clause
+
+### On your own machine
+
+1. [Download the Cicero template library](https://github.com/accordproject/cicero-template-library/archive/master.zip)
+
+2. Unzip the library with your favourite tool
+
+3. Then from the command-line, change the current directory to the folder containing this README.md file.
+```
+cd volumediscount
+```
+4. With the [Cicero command-line tool](https://github.com/accordproject/cicero#installation):
+```
+cicero execute --template ./ --dsl ./sample --data ./data.json
+```
+> Note, all of the command-line flags (like `--template`) are optional.
+
+Alternatively you can use the simpler command below if you want to use all of the default files.
+```
+cicero execute
+```
+
+You should see the following output in your terminal:
+```bash
+mattmbp:volumediscount matt$ cicero execute
+11:36:39 - info: Logging initialized. 2018-02-18T11:36:39.495Z
+11:36:40 - info: Using current directory as template folder
+11:36:40 - info: Loading a default sample.txt file.
+11:36:40 - info: Loading a default data.json file.
+11:36:40 - info: CICERO-ENGINE {"request":{"$class":"org.accordproject.volumediscount.VolumeDiscountRequest","netAnnualChargeVolume":0.4,"transactionId":"06b93a11-2d74-4030-a486-f35449ac032f","timestamp":"2018-02-18T11:36:40.340Z"},"response":{"$class":"org.accordproject.volumediscount.VolumeDiscountResponse","transactionId":"5f448219-851a-4b10-8fb9-14f979951ebd","timestamp":"2018-02-18T11:36:40.353Z"},"data":{"$class":"org.accordproject.volumediscount.TemplateModel","firstVolume":1,"secondVolume":10,"firstRate":3,"secondRate":2.9,"thirdRate":2.8}}
+11:36:40 - info: {"clause":"volumediscount@0.0.6-e6b68c35598afb65ddf51bfc40ada8cb482cb441605eb0285d46e708f8654d58","request":{"$class":"org.accordproject.volumediscount.VolumeDiscountRequest","netAnnualChargeVolume":0.4},"response":{"$class":"org.accordproject.volumediscount.VolumeDiscountResponse","discountRate":3,"transactionId":"5f448219-851a-4b10-8fb9-14f979951ebd","timestamp":"2018-02-18T11:36:40.353Z"}}
+```
+
+### Sample Payload Data
+
+
+Request, as in [data.json](https://github.com/accordproject/cicero-template-library/blob/master/perishable-goods/data.json)
+```json
+{
+    "$class": "org.accordproject.volumediscount.VolumeDiscountRequest",
+    "netAnnualChargeVolume": 0.4
+}
+```
+
+For the request above, you should see the following response:
+```json
+{
+    "$class":"org.accordproject.volumediscount.VolumeDiscountResponse",
+    "discountRate":3,
+    "transactionId":"5f448219-851a-4b10-8fb9-14f979951ebd",
+    "timestamp":"2018-02-18T11:36:40.353Z"
+}
+```
+
+
+## Testing this clause
+
+This clause comes with an automated test that ensures that it executes correctly under different conditions. To test the clause, complete the following steps.
+
+You need npm and node to test a clause. You can download both from [here](https://nodejs.org/).
+
+> This clause was tested with Node v8.9.3 and NPM v5.6.0
+
+From the `volumediscount` directory.
+
+1. Install all of the dependencies.
+```
+npm install
+```
+
+2. Run the tests
+```
+npm test
+```
+If successful, you should see the following output
+```
+mattmbp:volumediscount matt$ npm test
+
+> volumediscount@0.0.6 test /Users/matt/dev/mttrbrts/cicero-template-library/volumediscount
+> mocha
+
+11:37:53 - info: Logging initialized. 2018-02-18T11:37:53.706Z
+
+
+  Logic
+    #VolumeDiscount
+...
+      ✓ should execute a smart clause
+
+
+  1 passing (326ms)
+
+```
+> Output above is abbreviated for clarity at `...`

--- a/packages/cicero-engine/test/data/volumediscount/data.json
+++ b/packages/cicero-engine/test/data/volumediscount/data.json
@@ -1,0 +1,4 @@
+{
+    "$class": "org.accordproject.volumediscount.VolumeDiscountRequest",
+    "netAnnualChargeVolume": 0.4
+}

--- a/packages/cicero-engine/test/data/volumediscount/grammar/template.tem
+++ b/packages/cicero-engine/test/data/volumediscount/grammar/template.tem
@@ -1,0 +1,29 @@
+Volume-Based Card Acceptance Agreement [Abbreviated]
+
+This Agreement is by and between Card, Inc., a New York corporation, and you, the Merchant. By accepting the Card, you agree to be bound by the Agreement. 
+Discount means an amount that we charge you for accepting the Card, which amount is: 
+(i) a percentage (Discount Rate) of the face amount of the Charge that you submit, or a flat per-
+Transaction fee, or a combination of both; and/or 
+(ii) a Monthly Flat Fee (if you meet our requirements).
+
+Transaction Processing and Payments. Our Card acceptance, processing, and payment requirements are set forth in the Merchant Regulations. Some requirements are summarized here for ease of reference, but do not supersede the provisions in the Merchant Regulations.
+Payment for Charges. We will pay you, through our agent, according to your payment plan in US dollars for the face amount of Charges submitted from your Establishments less all applicable deductions, rejections, and withholdings, which include: 
+(i) the Discount, 
+(ii) any amounts you owe us or our Affiliates, 
+(iii) any amounts for which we have Chargebacks and 
+(iv) any Credits you submit. Your initial Discount is indicated in the Agreement or otherwise provided to you in writing by us. In addition to your Discount we may charge you additional fees and assessments, as listed in the Merchant Regulations or as otherwise provided to you in writing by us. We may adjust any of these amounts and may change any other amount we charge you for accepting the Card.
+
+SETTLEMENT
+a) Settlement Amount. Our agent will pay you according to your payment plan, as described below, in US dollars for the face amount of Charges submitted from your Establishments less all applicable deductions, rejections, and withholdings, which include: 
+    (i) the Discount, 
+    (ii) any amounts you owe us or our Affiliates, 
+    (iii) any amounts for which we have Chargebacks, and (iv) any Credits you submit. Our agent will subtract the full amount of all applicable deductions, rejections, and withholdings, from this payment to you (or debit your Bank Account), but if it cannot, then you must pay it promptly upon demand.
+b) Discount. The Discount is determined according to the following table:
+
+| Annual Dollar Volume      | Discount             |
+| Less than $[{firstVolume}] million      | [{firstRate}]%                |
+| $[{firstVolume}] million to $[{secondVolume}] million | [{secondRate}]%                |
+| Greater than $[{secondVolume}] million  | [{thirdRate}]%                |
+
+_______________________					_____________________
+ Card, Inc.								Merchant

--- a/packages/cicero-engine/test/data/volumediscount/lib/logic.js
+++ b/packages/cicero-engine/test/data/volumediscount/lib/logic.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/*eslint-disable no-unused-vars*/
+/*eslint-disable no-undef*/
+/*eslint-disable no-var*/
+
+/**
+ * Execute the smart clause
+ * @param {Context} context - the Accord context
+ * @param {org.accordproject.volumediscount.VolumeDiscountRequest} context.request - the incoming request
+ * @param {org.accordproject.volumediscount.VolumeDiscountResponse} context.response - the response
+ * @AccordClauseLogic
+ */
+function execute(context) {
+
+    logger.info(context);
+    var req = context.request;
+    var res = context.response;
+    var data = context.data;
+
+    // decision table
+    var netAnnualChargeVolume = req.netAnnualChargeVolume;
+
+    if (netAnnualChargeVolume < data.firstVolume) {
+	res.discountRate = data.firstRate;
+    } else if (netAnnualChargeVolume < data.secondVolume) {
+	res.discountRate = data.secondRate;
+    } else {
+	res.discountRate = data.thirdRate;
+    }
+    
+}
+
+/*eslint-enable no-unused-vars*/
+/*eslint-enable no-undef*/

--- a/packages/cicero-engine/test/data/volumediscount/lib/logic.txt
+++ b/packages/cicero-engine/test/data/volumediscount/lib/logic.txt
@@ -1,0 +1,1 @@
+# This is just text to test for other files

--- a/packages/cicero-engine/test/data/volumediscount/models/clause.cto
+++ b/packages/cicero-engine/test/data/volumediscount/models/clause.cto
@@ -1,0 +1,57 @@
+namespace org.accordproject.volumediscount
+
+/**
+ * Defines the data model for the VolumeDiscount template.
+ * This defines the structure of the abstract syntax tree that the parser for the template
+ * must generate from input source text.
+ */
+@AccordTemplateModel("volumediscount")
+concept TemplateModel {
+  /**
+   * First volume
+   */
+  o Double firstVolume
+
+  /**
+   * Second volume
+   */
+  o Double secondVolume
+
+  /**
+   * First rate
+   */
+  o Double firstRate
+
+  /**
+   * Second rate
+   */
+  o Double secondRate
+
+  /**
+   * Third rate
+   */
+  o Double thirdRate
+
+}
+
+/**
+ * Defines the input data required by the template
+ */
+transaction VolumeDiscountRequest {
+
+  /**
+   * 
+   */
+  o Double netAnnualChargeVolume
+
+}
+
+/**
+ * Defines the output data for the template
+ */
+transaction VolumeDiscountResponse {
+  /**
+   * The discount rate
+   */
+  o Double discountRate
+}

--- a/packages/cicero-engine/test/data/volumediscount/package-lock.json
+++ b/packages/cicero-engine/test/data/volumediscount/package-lock.json
@@ -1,0 +1,1431 @@
+{
+    "name": "volumediscount",
+    "version": "0.0.6",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+            "dev": true
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "dev": true
+        },
+        "@protobufjs/codegen": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+            "integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0=",
+            "dev": true
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+            "dev": true
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "dev": true,
+            "requires": {
+                "@protobufjs/aspromise": "1.1.2",
+                "@protobufjs/inquire": "1.1.0"
+            }
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+            "dev": true
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+            "dev": true
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+            "dev": true
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+            "dev": true
+        },
+        "@types/long": {
+            "version": "3.0.32",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+            "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+            "dev": true,
+            "optional": true
+        },
+        "@types/node": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+            "integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+            "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+            "dev": true
+        },
+        "any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+            "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bl": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+            "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "bluebird": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "browserfs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+            "integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+            "dev": true,
+            "requires": {
+                "async": "2.6.0",
+                "pako": "1.0.6"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+            "dev": true,
+            "requires": {
+                "pako": "0.2.9"
+            },
+            "dependencies": {
+                "pako": {
+                    "version": "0.2.9",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+                    "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+                    "dev": true
+                }
+            }
+        },
+        "chai": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+            "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.0.2",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.5"
+            }
+        },
+        "chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "requires": {
+                "check-error": "1.0.2"
+            }
+        },
+        "chai-things": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+            "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+            "dev": true
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+            "dev": true
+        },
+        "cicero-core": {
+            "version": "0.2.24",
+            "resolved": "https://registry.npmjs.org/cicero-core/-/cicero-core-0.2.24.tgz",
+            "integrity": "sha512-ws9lJ+LoBJUhrEIr6rfJ6TiQVjEhxgMwDq/Wt/RFOBT+8Jlz+X02MAvdy8DCr0vBuE3I1DuACc7z3hxgtzRnsg==",
+            "dev": true,
+            "requires": {
+                "composer-common": "0.16.2",
+                "config": "1.28.1",
+                "debug": "2.6.9",
+                "gunzip-maybe": "1.4.1",
+                "jszip": "3.1.5",
+                "minimatch": "3.0.4",
+                "moment": "2.20.1",
+                "moo": "0.4.3",
+                "nearley": "2.11.0",
+                "request-promise-native": "1.0.5",
+                "stream-to-string": "1.1.0",
+                "streamifier": "0.1.1",
+                "tar-fs": "1.16.0",
+                "tar-stream": "1.5.5",
+                "tmp-promise": "1.0.4",
+                "winston": "2.4.0"
+            }
+        },
+        "cicero-engine": {
+            "version": "0.2.24",
+            "resolved": "https://registry.npmjs.org/cicero-engine/-/cicero-engine-0.2.24.tgz",
+            "integrity": "sha512-PKvMbExdERAjbduvSgSqDWTuYiKu9+IE95yryTsvcVl9+mslMRO/O8+aBxPYkq2f5mV0gIkckKRoPIDsYX4FAg==",
+            "dev": true,
+            "requires": {
+                "cicero-core": "0.2.24",
+                "composer-common": "0.16.2",
+                "config": "1.28.1",
+                "debug": "2.6.9",
+                "moment": "2.20.1",
+                "nearley": "2.11.0",
+                "vm2": "3.5.2",
+                "winston": "2.4.0"
+            }
+        },
+        "colors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true,
+            "requires": {
+                "graceful-readlink": "1.0.1"
+            }
+        },
+        "comment-parser": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+            "integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
+        },
+        "composer-common": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.16.2.tgz",
+            "integrity": "sha512-qryn6aDvq1iAxgQq+QVA8p617RyCM8tWVv2NLxrpVnlHTR9N09psErYsaksudEbtG4hSL5l0lS+gTNVpqXGV7A==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.1.2",
+                "browserfs": "1.1.0",
+                "commander": "2.9.0",
+                "comment-parser": "0.4.0",
+                "config": "1.24.0",
+                "debug": "2.6.2",
+                "doctrine": "2.0.0",
+                "esprima": "3.1.2",
+                "fs-promise": "1.0.0",
+                "homedir": "0.6.0",
+                "jszip": "3.1.3",
+                "left-pad": "1.1.3",
+                "lorem-ipsum": "1.0.4",
+                "minimatch": "3.0.3",
+                "mkdirp": "0.5.1",
+                "node-plantuml": "0.5.0",
+                "protobufjs": "6.6.3",
+                "proxyquire": "1.7.11",
+                "rimraf": "2.5.4",
+                "semver": "5.3.0",
+                "sprintf-js": "1.0.3",
+                "temp": "0.8.3",
+                "thenify": "3.2.1",
+                "thenify-all": "1.6.0",
+                "uri-js": "3.0.2",
+                "uuid": "3.0.1",
+                "winston": "2.3.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true
+                },
+                "config": {
+                    "version": "1.24.0",
+                    "resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+                    "integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+                    "dev": true,
+                    "requires": {
+                        "json5": "0.4.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+                    "integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "0.7.2"
+                    }
+                },
+                "jszip": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+                    "integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+                    "dev": true,
+                    "requires": {
+                        "core-js": "2.3.0",
+                        "es6-promise": "3.0.2",
+                        "lie": "3.1.1",
+                        "pako": "1.0.6",
+                        "readable-stream": "2.0.6"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                    "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "winston": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+                    "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+                    "dev": true,
+                    "requires": {
+                        "async": "1.0.0",
+                        "colors": "1.0.3",
+                        "cycle": "1.0.3",
+                        "eyes": "0.1.8",
+                        "isstream": "0.1.2",
+                        "stack-trace": "0.0.10"
+                    }
+                }
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "config": {
+            "version": "1.28.1",
+            "resolved": "https://registry.npmjs.org/config/-/config-1.28.1.tgz",
+            "integrity": "sha1-diXSoeTJDxMdinM0eYLZPDhzKC0=",
+            "dev": true,
+            "requires": {
+                "json5": "0.4.0",
+                "os-homedir": "1.0.2"
+            }
+        },
+        "core-js": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+            "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.5"
+            }
+        },
+        "diff": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "dev": true
+        },
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+            }
+        },
+        "duplexify": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+            "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+            "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "es6-promise": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+            "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+            "integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+            "dev": true
+        },
+        "fill-keys": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+            "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+            "dev": true,
+            "requires": {
+                "is-object": "1.0.1",
+                "merge-descriptors": "1.0.1"
+            }
+        },
+        "fs-extra": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "jsonfile": "2.4.0",
+                "klaw": "1.3.1"
+            }
+        },
+        "fs-promise": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+            "integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0",
+                "fs-extra": "1.0.0",
+                "mz": "2.7.0",
+                "thenify-all": "1.6.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "dev": true
+        },
+        "gunzip-maybe": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+            "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+            "dev": true,
+            "requires": {
+                "browserify-zlib": "0.1.4",
+                "is-deflate": "1.0.0",
+                "is-gzip": "1.0.0",
+                "peek-stream": "1.1.2",
+                "pumpify": "1.3.5",
+                "through2": "2.0.3"
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "homedir": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+            "integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4=",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "is-deflate": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+            "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=",
+            "dev": true
+        },
+        "is-gzip": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+            "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
+            "dev": true
+        },
+        "is-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+            "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "jszip": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "dev": true,
+            "requires": {
+                "core-js": "2.3.0",
+                "es6-promise": "3.0.2",
+                "lie": "3.1.1",
+                "pako": "1.0.6",
+                "readable-stream": "2.0.6"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "left-pad": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+            "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=",
+            "dev": true
+        },
+        "lie": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "dev": true,
+            "requires": {
+                "immediate": "3.0.6"
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+            "dev": true,
+            "optional": true
+        },
+        "lorem-ipsum": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+            "integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+            "dev": true,
+            "requires": {
+                "optimist": "0.3.7"
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+            "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "4.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "module-not-found-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+            "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+            "dev": true
+        },
+        "moment": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+            "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+            "dev": true
+        },
+        "moo": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+            "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+            "dev": true
+        },
+        "ms": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+            "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+            "dev": true
+        },
+        "mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0",
+                "object-assign": "4.1.1",
+                "thenify-all": "1.6.0"
+            }
+        },
+        "nearley": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.0.tgz",
+            "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
+            "dev": true,
+            "requires": {
+                "nomnom": "1.6.2",
+                "railroad-diagrams": "1.0.0",
+                "randexp": "0.4.6"
+            }
+        },
+        "node-nailgun-client": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+            "integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0"
+            }
+        },
+        "node-nailgun-server": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+            "integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0"
+            }
+        },
+        "node-plantuml": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+            "integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+            "dev": true,
+            "requires": {
+                "commander": "2.9.0",
+                "node-nailgun-client": "0.1.0",
+                "node-nailgun-server": "0.1.3",
+                "plantuml-encoder": "1.2.4"
+            }
+        },
+        "nomnom": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+            "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+            "dev": true,
+            "requires": {
+                "colors": "0.5.1",
+                "underscore": "1.4.4"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+                    "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+                    "dev": true
+                }
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "optimist": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+            "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+            "dev": true,
+            "requires": {
+                "wordwrap": "0.0.3"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "peek-stream": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.2.tgz",
+            "integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.1",
+                "through2": "2.0.3"
+            }
+        },
+        "plantuml-encoder": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.4.tgz",
+            "integrity": "sha1-XwBW98BL12ru9CC/zd7zOen0QIE=",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.3",
+                "utf8-bytes": "0.0.1"
+            },
+            "dependencies": {
+                "pako": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+                    "integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8=",
+                    "dev": true
+                }
+            }
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "promise-polyfill": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+            "integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc=",
+            "dev": true
+        },
+        "protobufjs": {
+            "version": "6.6.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+            "integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+            "dev": true,
+            "requires": {
+                "@protobufjs/aspromise": "1.1.2",
+                "@protobufjs/base64": "1.1.2",
+                "@protobufjs/codegen": "1.0.8",
+                "@protobufjs/eventemitter": "1.1.0",
+                "@protobufjs/fetch": "1.1.0",
+                "@protobufjs/inquire": "1.1.0",
+                "@protobufjs/path": "1.1.2",
+                "@protobufjs/pool": "1.1.0",
+                "@protobufjs/utf8": "1.1.0",
+                "@types/long": "3.0.32",
+                "@types/node": "7.0.4",
+                "long": "3.2.0"
+            }
+        },
+        "proxyquire": {
+            "version": "1.7.11",
+            "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+            "integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+            "dev": true,
+            "requires": {
+                "fill-keys": "1.0.2",
+                "module-not-found-error": "1.0.1",
+                "resolve": "1.1.7"
+            }
+        },
+        "pump": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+            "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
+            }
+        },
+        "pumpify": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+            "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.1",
+                "inherits": "2.0.3",
+                "pump": "1.0.3"
+            }
+        },
+        "punycode": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+            "dev": true
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+            "dev": true
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dev": true,
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "0.1.15"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "request-promise-core": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "request-promise-native": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "dev": true,
+            "requires": {
+                "request-promise-core": "1.1.1",
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.3"
+            }
+        },
+        "resolve": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+            "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+            "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "dev": true
+        },
+        "stealthy-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "stream-to-string": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+            "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+            "dev": true,
+            "requires": {
+                "promise-polyfill": "1.1.6"
+            }
+        },
+        "streamifier": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "supports-color": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "2.0.0"
+            }
+        },
+        "tar-fs": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+            "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+            "dev": true,
+            "requires": {
+                "chownr": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pump": "1.0.3",
+                "tar-stream": "1.5.5"
+            }
+        },
+        "tar-stream": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "dev": true,
+            "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "temp": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+            "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2",
+                "rimraf": "2.2.8"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.2.8",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
+                }
+            }
+        },
+        "thenify": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+            "integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+            "dev": true,
+            "requires": {
+                "any-promise": "1.3.0"
+            }
+        },
+        "thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+            "dev": true,
+            "requires": {
+                "thenify": "3.2.1"
+            }
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "tmp-promise": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+            "integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+            "dev": true,
+            "requires": {
+                "bluebird": "3.5.1",
+                "tmp": "0.0.33"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "type-detect": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+            "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+            "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            }
+        },
+        "utf8-bytes": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+            "integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+            "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+            "dev": true
+        },
+        "vm2": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+            "integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg==",
+            "dev": true
+        },
+        "winston": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+            "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+            "dev": true,
+            "requires": {
+                "async": "1.0.0",
+                "colors": "1.0.3",
+                "cycle": "1.0.3",
+                "eyes": "0.1.8",
+                "isstream": "0.1.2",
+                "stack-trace": "0.0.10"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+                    "dev": true
+                }
+            }
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        }
+    }
+}

--- a/packages/cicero-engine/test/data/volumediscount/package.json
+++ b/packages/cicero-engine/test/data/volumediscount/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "volumediscount",
+    "version": "0.0.6",
+    "description": "A sample volume discount clause.",
+    "engines": {
+        "cicero": "^0.2.28"
+    },
+    "scripts": {
+        "test": "mocha",
+        "parse": "cicero parse --template ./ --dsl sample.txt",
+        "execute": "cicero execute --template ./ --dsl sample.txt --data data.json"
+    },
+    "devDependencies": {
+        "chai": "^4.1.2",
+        "chai-as-promised": "^7.1.1",
+        "chai-things": "^0.2.0",
+        "cicero-core": "^0.2.13",
+        "cicero-engine": "^0.2.13",
+        "mocha": "^4.0.1",
+        "moment": "^2.19.2"
+    }
+}

--- a/packages/cicero-engine/test/data/volumediscount/sample.txt
+++ b/packages/cicero-engine/test/data/volumediscount/sample.txt
@@ -1,0 +1,29 @@
+Volume-Based Card Acceptance Agreement [Abbreviated]
+
+This Agreement is by and between Card, Inc., a New York corporation, and you, the Merchant. By accepting the Card, you agree to be bound by the Agreement. 
+Discount means an amount that we charge you for accepting the Card, which amount is: 
+(i) a percentage (Discount Rate) of the face amount of the Charge that you submit, or a flat per-
+Transaction fee, or a combination of both; and/or 
+(ii) a Monthly Flat Fee (if you meet our requirements).
+
+Transaction Processing and Payments. Our Card acceptance, processing, and payment requirements are set forth in the Merchant Regulations. Some requirements are summarized here for ease of reference, but do not supersede the provisions in the Merchant Regulations.
+Payment for Charges. We will pay you, through our agent, according to your payment plan in US dollars for the face amount of Charges submitted from your Establishments less all applicable deductions, rejections, and withholdings, which include: 
+(i) the Discount, 
+(ii) any amounts you owe us or our Affiliates, 
+(iii) any amounts for which we have Chargebacks and 
+(iv) any Credits you submit. Your initial Discount is indicated in the Agreement or otherwise provided to you in writing by us. In addition to your Discount we may charge you additional fees and assessments, as listed in the Merchant Regulations or as otherwise provided to you in writing by us. We may adjust any of these amounts and may change any other amount we charge you for accepting the Card.
+
+SETTLEMENT
+a) Settlement Amount. Our agent will pay you according to your payment plan, as described below, in US dollars for the face amount of Charges submitted from your Establishments less all applicable deductions, rejections, and withholdings, which include: 
+    (i) the Discount, 
+    (ii) any amounts you owe us or our Affiliates, 
+    (iii) any amounts for which we have Chargebacks, and (iv) any Credits you submit. Our agent will subtract the full amount of all applicable deductions, rejections, and withholdings, from this payment to you (or debit your Bank Account), but if it cannot, then you must pay it promptly upon demand.
+b) Discount. The Discount is determined according to the following table:
+
+| Annual Dollar Volume      | Discount             |
+| Less than $1 million      | 3.00%                |
+| $1 million to $10 million | 2.90%                |
+| Greater than $10 million  | 2.80%                |
+
+_______________________					_____________________
+ Card, Inc.								Merchant

--- a/packages/cicero-engine/test/data/volumediscount/test/logic.js
+++ b/packages/cicero-engine/test/data/volumediscount/test/logic.js
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const Template = require('cicero-core').Template;
+const Clause = require('cicero-core').Clause;
+const Engine = require('cicero-engine').Engine;
+
+const fs = require('fs');
+const path = require('path');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-things'));
+chai.use(require('chai-as-promised'));
+const moment = require('moment');
+
+describe('Logic', () => {
+
+    const rootDir = path.resolve(__dirname, '..');
+    const clauseText = fs.readFileSync(path.resolve(rootDir, 'sample.txt'), 'utf8');
+    
+    let template;
+    let clause;
+    let engine;    
+
+    beforeEach( async function() {
+        template = await Template.fromDirectory(rootDir);
+        clause = new Clause(template);
+        clause.parse(clauseText);
+        engine = new Engine();
+    });
+    
+    describe('#VolumeDiscount', async function() {
+
+        it('should execute a smart clause', async function () {
+            const request = {
+		"$class": "org.accordproject.volumediscount.VolumeDiscountRequest",
+		"netAnnualChargeVolume": 0.4
+	    };
+            const result = await engine.execute(clause, request);
+            result.should.not.be.null;
+            result.response.discountRate.should.equal(3);
+        });
+    });
+});

--- a/packages/cicero-engine/test/engine.js
+++ b/packages/cicero-engine/test/engine.js
@@ -26,7 +26,7 @@ chai.use(require('chai-things'));
 const fs = require('fs');
 const path = require('path');
 
-describe('Engine', () => {
+describe('EngineLatePenalty', () => {
 
     let engine;
     let clause;
@@ -52,9 +52,96 @@ describe('Engine', () => {
                 'transactionId': '402c8f50-9e61-433e-a7c1-afe61c06ef00',
                 'timestamp': '2017-11-12T17:38:01.412Z'
             };
-            const result = await engine.execute(clause, request);
+            const result = await engine.execute(clause, request, true);
             result.should.not.be.null;
             result.response.penalty.should.equal(110.00000000000001);
+        });
+    });
+    describe('#executejura', function () {
+
+        it('should execute a smart clause', async function () {
+            const request = {
+                '$class': 'io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest',
+                'forceMajeure': false,
+                'agreedDelivery': '2017-10-07T16:38:01.412Z',
+                'goodsValue': 200.00,
+                'transactionId': '402c8f50-9e61-433e-a7c1-afe61c06ef00',
+                'timestamp': '2017-11-12T17:38:01.412Z'
+            };
+            const result = await engine.execute(clause, request, false);
+            result.should.not.be.null;
+            result.response.penalty.should.equal(110);
+        });
+    });
+});
+describe('EngineVolumeDiscount', () => {
+
+    let engine;
+    let clause;
+    const volumeDiscountInput = fs.readFileSync(path.resolve(__dirname, 'data/volumediscount', 'sample.txt'), 'utf8');
+
+    beforeEach(async function () {
+        engine = new Engine();
+        const template = await Template.fromDirectory('./test/data/volumediscount');
+        clause = new Clause(template);
+        clause.parse(volumeDiscountInput);
+    });
+
+    afterEach(() => {});
+
+    describe('#execute', function () {
+
+        it('should execute a smart clause', async function () {
+            const request = {
+                '$class': 'org.accordproject.volumediscount.VolumeDiscountRequest',
+                'netAnnualChargeVolume': 0.4
+            };
+            const result = await engine.execute(clause, request, true);
+            result.should.not.be.null;
+            result.response.discountRate.should.equal(3);
+        });
+    });
+});
+describe('EngineHelloWorld', () => {
+
+    let engine;
+    let clause;
+    const helloWorldInput = fs.readFileSync(path.resolve(__dirname, 'data/helloworld', 'sample.txt'), 'utf8');
+
+    beforeEach(async function () {
+        engine = new Engine();
+        const template = await Template.fromDirectory('./test/data/helloworld');
+        clause = new Clause(template);
+        clause.parse(helloWorldInput);
+    });
+
+    afterEach(() => {});
+
+    describe('#execute', function () {
+
+        it('should execute a smart clause', async function () {
+            const request = {
+                '$class': 'org.accordproject.helloworld.Request',
+                'input': 'Accord Project'
+            };
+            const result = await engine.execute(clause, request, false);
+            result.should.not.be.null;
+            result.response.output.should.equal('Hello Fred Blogs (Accord Project)');
+        });
+    });
+    describe('#execute2', function () {
+
+        it('should execute a smart clause', async function () {
+            try {
+                const request = {
+                    '$class': 'org.accordproject.helloworld.Request',
+                    'input': 'Accord Project'
+                };
+                const result = await engine.execute(clause, request, true);
+                return result;
+            } catch (err) {
+                err.should.be.Error;
+            }
         });
     });
 });

--- a/packages/cicero-server/CHANGELOG.md
+++ b/packages/cicero-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package cicero-server
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/packages/cicero-server/package.json
+++ b/packages/cicero-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cicero-server",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Cicero Server - wraps the Cicero Engine and exposes it as a RESTful service",
   "engines": {
     "node": ">=8",
@@ -48,8 +48,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.43",
-    "cicero-engine": "^0.2.43",
+    "cicero-core": "^0.2.44",
+    "cicero-engine": "^0.2.44",
     "express": "^4.16.2"
   },
   "license-check-config": {

--- a/packages/generator-cicero-template/CHANGELOG.md
+++ b/packages/generator-cicero-template/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.44"></a>
+## [0.2.44](https://github.com/accordproject/cicero/compare/v0.2.43...v0.2.44) (2018-02-17)
+
+
+
+
+**Note:** Version bump only for package generator-cicero-template
+
 <a name="0.2.43"></a>
 ## [0.2.43](https://github.com/accordproject/cicero/compare/v0.2.42...v0.2.43) (2018-02-16)
 

--- a/packages/generator-cicero-template/package.json
+++ b/packages/generator-cicero-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cicero-template",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Code generator for a Cicero Template",
   "engines": {
     "node": ">=8",


### PR DESCRIPTION
Allows Cicero to load and execute Jura files. This is initial support and needs to be tested. Jura execution is only enabled if the `--withjura` flag is set on the command line. The loading of the logic is that JavaScript takes precedence if present in the `lib` directory for a given template. If no JavaScript logic matches the transaction request, the Jura logic is called.