### PR TITLE
chore: Move npm packages under @accordproject scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.46",
+  "version": "0.2.48",
   "hoist": true,
   "command": {
     "publish": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,79 @@
 {
-	"name": "cicero",
-	"version": "0.2.39",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+		},
+		"@protobufjs/codegen": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-1.0.8.tgz",
+			"integrity": "sha1-0p49SKlEXXfMv/pCA3myncN8bX0="
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/inquire": "1.1.0"
+			}
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+		},
+		"@sinonjs/formatio": {
+			"version": "2.0.0",
+			"resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+			"integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"@types/long": {
+			"version": "3.0.32",
+			"resolved": "https://registry.npmjs.org/@types/long/-/long-3.0.32.tgz",
+			"integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA==",
+			"optional": true
+		},
+		"@types/node": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.4.tgz",
+			"integrity": "sha1-mqvBNZed7TgzJXSfUIiUxmKUjIs="
+		},
 		"JSONStream": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
 			"integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-			"dev": true,
 			"requires": {
 				"jsonparse": "1.3.1",
 				"through": "2.3.8"
@@ -17,20 +82,61 @@
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-			"dev": true
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "2.1.18",
+				"negotiator": "0.6.1"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "1.33.0"
+					}
+				}
+			}
+		},
+		"acorn": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+			"integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+				}
+			}
 		},
 		"add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-			"dev": true
+			"integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo="
 		},
 		"ajv": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
 			"integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
-			"dev": true,
 			"requires": {
 				"co": "4.6.0",
 				"fast-deep-equal": "1.0.0",
@@ -38,11 +144,15 @@
 				"json-schema-traverse": "0.3.1"
 			}
 		},
+		"ajv-keywords": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+			"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+		},
 		"align-text": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2",
 				"longest": "1.0.1",
@@ -52,32 +162,53 @@
 		"amdefine": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-escapes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
-			"dev": true
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "1.9.1"
+			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
 		},
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
 			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"dev": true,
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.3"
@@ -87,28 +218,47 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "1.0.3"
 			}
 		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true,
 			"requires": {
 				"array-uniq": "1.0.3"
 			}
@@ -116,84 +266,202 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-			"dev": true
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-			"dev": true
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-			"dev": true
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"axios": {
+			"version": "0.17.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"requires": {
+				"follow-redirects": "1.4.1",
+				"is-buffer": "1.1.5"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
 		},
 		"babylon": {
 			"version": "7.0.0-beta.19",
 			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-			"dev": true
+			"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"tweetnacl": "0.14.5"
 			}
 		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+		},
+		"binaryextensions": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
+			"integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
+		},
 		"bindings": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-			"dev": true
+			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+		},
+		"bl": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"requires": {
+				"readable-stream": "2.3.6",
+				"safe-buffer": "5.1.1"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
 		},
 		"bluebird": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-			"dev": true
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+		},
+		"body-parser": {
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+			"integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.19",
+				"on-finished": "2.3.0",
+				"qs": "6.5.1",
+				"raw-body": "2.3.2",
+				"type-is": "1.6.16"
+			}
 		},
 		"boom": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -202,35 +470,102 @@
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-			"dev": true,
 			"requires": {
 				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+			"integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
+		},
+		"browserfs": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.4.3.tgz",
+			"integrity": "sha512-tz8HClVrzTJshcyIu8frE15cjqjcBIu15Bezxsvl/i+6f59iNCN3kznlWjz0FEb3DlnDx3gW5szxeT6D1x0s0w==",
+			"requires": {
+				"async": "2.6.0",
+				"pako": "1.0.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"requires": {
+						"lodash": "4.17.5"
+					}
+				}
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+			"requires": {
+				"pako": "0.2.9"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				}
+			}
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-			"dev": true
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
 			"requires": {
 				"camelcase": "2.1.1",
 				"map-obj": "1.0.1"
@@ -239,26 +574,22 @@
 		"canonical-path": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
-			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ=",
-			"dev": true
+			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ="
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-			"dev": true
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"catharsis": {
 			"version": "0.8.9",
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
 			"integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-			"dev": true,
 			"requires": {
 				"underscore-contrib": "0.3.0"
 			}
@@ -267,45 +598,137 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4",
 				"lazy-cache": "1.0.4"
 			}
 		},
+		"chai": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+			"requires": {
+				"assertion-error": "1.1.0",
+				"deep-eql": "0.1.3",
+				"type-detect": "1.0.0"
+			}
+		},
+		"chai-as-promised": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-6.0.0.tgz",
+			"integrity": "sha1-GgKkM6byTa+sY7nJb6FoTbGqjaY=",
+			"requires": {
+				"check-error": "1.0.2"
+			}
+		},
+		"chai-things": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+			"integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA="
+		},
+		"chalk": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.3.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
 		"chardet": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
+			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+		},
+		"chownr": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+			"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
 		},
 		"ci-info": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
-			"dev": true
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+		},
+		"class-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.2.tgz",
+			"integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
+			"requires": {
+				"object-assign": "2.1.1"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				}
+			}
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
 		},
 		"cli-cursor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-table": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+			"integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+			"requires": {
+				"colors": "1.0.3"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				}
 			}
 		},
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"center-align": "0.1.3",
@@ -317,7 +740,6 @@
 					"version": "0.0.2",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
 					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -325,14 +747,61 @@
 		"clone": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-			"dev": true
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+		},
+		"clone-buffer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"cloneable-readable": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+			"requires": {
+				"inherits": "2.0.3",
+				"process-nextick-args": "2.0.0",
+				"readable-stream": "2.3.6"
+			},
+			"dependencies": {
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
 		},
 		"cmd-shim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"mkdirp": "0.5.1"
@@ -341,20 +810,17 @@
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color-convert": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -362,20 +828,22 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
 		},
 		"colors": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-			"dev": true
+			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 		},
 		"columnify": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "3.0.1",
 				"wcwidth": "1.0.1"
@@ -385,7 +853,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "1.0.0"
 			}
@@ -393,36 +860,209 @@
 		"command-join": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-			"dev": true
+			"integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8="
 		},
 		"commander": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-			"integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-			"dev": true
+			"integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
+		},
+		"comment-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.4.0.tgz",
+			"integrity": "sha1-snSjySS2suVXaPcSrNPjADy1X1c=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "1.0.0",
 				"dot-prop": "3.0.0"
 			}
 		},
+		"composer-common": {
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.17.4.tgz",
+			"integrity": "sha512-/L6qSq9XbbEbQGvcR6qBd51Eezixt4R9MLJ50ZKUeoW2RzxFVLeHozwXuTsooXVAC3/PCyTE711MmcNNRnNT8Q==",
+			"requires": {
+				"acorn": "5.1.2",
+				"axios": "0.17.1",
+				"browserfs": "1.1.0",
+				"commander": "2.9.0",
+				"comment-parser": "0.4.0",
+				"config": "1.24.0",
+				"debug": "2.6.2",
+				"doctrine": "2.0.0",
+				"esprima": "3.1.2",
+				"fs-promise": "1.0.0",
+				"homedir": "0.6.0",
+				"js-yaml": "3.10.0",
+				"jszip": "3.1.3",
+				"left-pad": "1.1.3",
+				"lorem-ipsum": "1.0.4",
+				"minimatch": "3.0.3",
+				"mkdirp": "0.5.1",
+				"node-plantuml": "0.5.0",
+				"protobufjs": "6.6.3",
+				"proxyquire": "1.7.11",
+				"rimraf": "2.5.4",
+				"semver": "5.3.0",
+				"sprintf-js": "1.0.3",
+				"temp": "0.8.3",
+				"thenify": "3.2.1",
+				"thenify-all": "1.6.0",
+				"uri-js": "3.0.2",
+				"uuid": "3.0.1",
+				"winston": "2.3.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"requires": {
+						"lodash": "4.17.5"
+					}
+				},
+				"browserfs": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.1.0.tgz",
+					"integrity": "sha1-BD904L5W5A7VxR3x1yAZ7m/R+4s=",
+					"requires": {
+						"async": "2.6.0",
+						"pako": "1.0.6"
+					}
+				},
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				},
+				"commander": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+					"requires": {
+						"graceful-readlink": "1.0.1"
+					}
+				},
+				"config": {
+					"version": "1.24.0",
+					"resolved": "https://registry.npmjs.org/config/-/config-1.24.0.tgz",
+					"integrity": "sha1-VTvE13Y31mMKMFtSwzy22iufQvA=",
+					"requires": {
+						"json5": "0.4.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.2.tgz",
+					"integrity": "sha1-36lqhh7puMLyk0mzvMQapZmnHg8=",
+					"requires": {
+						"ms": "0.7.2"
+					}
+				},
+				"jszip": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.3.tgz",
+					"integrity": "sha1-ipIEA7KxZRwPwSa+kBktkICVfDc=",
+					"requires": {
+						"core-js": "2.3.0",
+						"es6-promise": "3.0.2",
+						"lie": "3.1.1",
+						"pako": "1.0.6",
+						"readable-stream": "2.0.6"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+					"requires": {
+						"brace-expansion": "1.1.8"
+					}
+				},
+				"ms": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+				},
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.5.4",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+					"integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+				},
+				"winston": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+					"integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+					"requires": {
+						"async": "1.0.0",
+						"colors": "1.0.3",
+						"cycle": "1.0.3",
+						"eyes": "0.1.8",
+						"isstream": "0.1.2",
+						"stack-trace": "0.0.10"
+					},
+					"dependencies": {
+						"async": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+							"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+						}
+					}
+				}
+			}
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-			"dev": true,
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3",
@@ -433,7 +1073,6 @@
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.1.tgz",
 			"integrity": "sha512-689HrwGw8Rbk1xtV9C4dY6TPJAvIYZbRbnKSAtfJ7tHqICFGoZ0PCWYjxfmerRyxBG0o3sbG3pe7N8vqPwIHuQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "0.5.1",
 				"commander": "2.6.0",
@@ -448,20 +1087,17 @@
 				"ansi-regex": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-					"dev": true
+					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
 				},
 				"ansi-styles": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-					"dev": true
+					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
 				},
 				"chalk": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
 					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "1.1.0",
 						"escape-string-regexp": "1.0.5",
@@ -473,8 +1109,7 @@
 						"supports-color": {
 							"version": "0.2.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-							"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-							"dev": true
+							"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
 						}
 					}
 				},
@@ -482,24 +1117,40 @@
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
 					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "0.2.1"
 					}
 				}
 			}
 		},
+		"config": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/config/-/config-1.30.0.tgz",
+			"integrity": "sha1-HWCp81NIoTwXV5jThOgaWhbDum4=",
+			"requires": {
+				"json5": "0.4.0",
+				"os-homedir": "1.0.2"
+			}
+		},
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
 		"conventional-changelog": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.11.tgz",
 			"integrity": "sha512-GQgcaBhuTKTNGAZM5mQgTO76G9FJTPwdrT1AeFuXQpQ9v+FbaWKRjWyT9wvCYNNCQnpiSJBsg+2537iuG4bnQQ==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-angular": "1.6.2",
 				"conventional-changelog-atom": "0.2.0",
@@ -517,7 +1168,6 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.2.tgz",
 			"integrity": "sha512-LiGZkMJOCJFLNzDlZo3f+DpblcDSzsaYHUWhC+kzsqq+no4qwDP3uW0HVIHueXT4jJDhYNaE9t/XCD7vu7xR1g==",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"q": "1.5.0"
@@ -527,7 +1177,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.0.tgz",
 			"integrity": "sha1-cvGOXHTj2IB0ESUv4BOBjd/6cVc=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -536,7 +1185,6 @@
 			"version": "1.3.9",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.9.tgz",
 			"integrity": "sha512-wkM9yd228M8ZolJK38dEAoqangngv8vSzV/NJTxG/6sqMiuiiVnj5GBt6CepuQusVlri/0g/VZHHLi/yCVnaqg==",
-			"dev": true,
 			"requires": {
 				"add-stream": "1.0.0",
 				"conventional-changelog": "1.1.11",
@@ -549,7 +1197,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.0.tgz",
 			"integrity": "sha1-TdirufUhpjjKtJ9oNJbCa4pcbTE=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -558,7 +1205,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.1.tgz",
 			"integrity": "sha512-XxgSDsCUGXT4j3uVpYkz17D1AoWzO8BOC0VO1fSwvvXJB5Q32zhPGXObvu7vTb0GE0OS15eDgzYN32fU3mOzYA==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "3.0.0",
 				"conventional-commits-parser": "2.1.1",
@@ -579,7 +1225,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -592,7 +1237,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -605,7 +1249,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.2.tgz",
 			"integrity": "sha512-ZigC7cz6rLzHk4YHnhfd85mxCyRQqiI8CMwalCVC8jIsplxswm+u3F16dIx5Z/P/A5VYFtv4H4ndhccTKS13jw==",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -614,7 +1257,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.0.tgz",
 			"integrity": "sha1-xjzZ1vCdTiBFMK5zadeiChZ7xrw=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -623,7 +1265,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.0.tgz",
 			"integrity": "sha1-XtAG9IaC2GFe4KtfU8rLJvvT4cg=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -632,7 +1273,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
 			"integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -641,7 +1281,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
 			"integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-			"dev": true,
 			"requires": {
 				"q": "1.5.0"
 			}
@@ -650,7 +1289,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.0.tgz",
 			"integrity": "sha1-A5P9RoETuvc8upEdF8WCZCM2aig=",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"q": "1.5.0"
@@ -660,7 +1298,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.0.tgz",
 			"integrity": "sha1-4QYVTtlDQeOH1xe2G+IYH/UyVMw=",
-			"dev": true,
 			"requires": {
 				"compare-func": "1.3.2",
 				"conventional-commits-filter": "1.1.1",
@@ -678,7 +1315,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz",
 			"integrity": "sha512-bQyatySNKHhcaeKVr9vFxYWA1W1Tdz6ybVMYDmv4/FhOXY1+fchiW07TzRbIQZhVa4cvBwrEaEUQBbCncFSdJQ==",
-			"dev": true,
 			"requires": {
 				"is-subset": "0.1.1",
 				"modify-values": "1.0.0"
@@ -688,7 +1324,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.1.tgz",
 			"integrity": "sha512-Qqxaul7TELPnTrm7KhWGjVTFTs7T9yUblzXugtXEff2C2uXFK4S0uVGqsyX7feQZzoFbXnJ1KdEs+IMmSxGbqQ==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "1.3.2",
 				"is-text-path": "1.0.1",
@@ -703,7 +1338,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
 			"integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "1.6.0",
 				"conventional-commits-filter": "1.1.1",
@@ -714,17 +1348,35 @@
 				"object-assign": "4.1.1"
 			}
 		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"core-js": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+			"integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"coveralls": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
 			"integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
-			"dev": true,
 			"requires": {
 				"js-yaml": "3.10.0",
 				"lcov-parse": "0.0.10",
@@ -736,8 +1388,7 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
 		},
@@ -745,7 +1396,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"dev": true,
 			"requires": {
 				"capture-stack-trace": "1.0.0"
 			}
@@ -754,7 +1404,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
@@ -765,7 +1414,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"dev": true,
 			"requires": {
 				"boom": "5.2.0"
 			},
@@ -774,7 +1422,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"dev": true,
 					"requires": {
 						"hoek": "4.2.0"
 					}
@@ -785,16 +1432,19 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "1.0.2"
 			}
+		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
 		},
 		"dargs": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -803,7 +1453,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
 			}
@@ -811,14 +1460,12 @@
 		"date-fns": {
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
-			"dev": true
+			"integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
 		},
 		"dateformat": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
 			"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-			"dev": true,
 			"requires": {
 				"get-stdin": "4.0.1",
 				"meow": "3.7.0"
@@ -828,68 +1475,152 @@
 			"version": "0.1.11",
 			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.11.tgz",
 			"integrity": "sha1-PR8iii/s9KGzWdouY2iJlC+L8Uw=",
-			"dev": true,
 			"requires": {
 				"bindings": "1.2.1",
 				"nan": "2.8.0"
 			}
 		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "1.0.0"
+			}
 		},
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+		},
+		"deep-eql": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+			"requires": {
+				"type-detect": "0.1.1"
+			},
+			"dependencies": {
+				"type-detect": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+					"integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+				}
+			}
 		},
 		"deep-extend": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-			"dev": true
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "1.0.3"
+			}
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.1",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"requires": {
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				}
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"detect-conflict": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
+			"integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
 		},
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+		},
+		"diff": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
+		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+		},
+		"doctrine": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+			"requires": {
+				"esutils": "2.0.2",
+				"isarray": "1.0.0"
+			}
 		},
 		"dot-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-			"dev": true,
 			"requires": {
 				"is-obj": "1.0.1"
 			}
@@ -897,51 +1628,327 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"dev": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"duplexify": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"jsbn": "0.1.1"
+			}
+		},
+		"editions": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"ejs": {
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
+			"integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ=="
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"error": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"requires": {
+				"string-template": "0.2.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"error-ex": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "0.2.1"
 			}
 		},
+		"es6-promise": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+			"integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"requires": {
+				"esprima": "2.7.3",
+				"estraverse": "1.9.3",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.2.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+				},
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"optional": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"eslint": {
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"requires": {
+				"ajv": "5.4.0",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.2",
+				"concat-stream": "1.6.0",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.4.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.5",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.1.0",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "4.0.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"requires": {
+						"esutils": "2.0.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"requires": {
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+		},
+		"espree": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+			"requires": {
+				"acorn": "5.5.3",
+				"acorn-jsx": "3.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.5.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+					"integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+				}
+			}
+		},
+		"esprima": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.2.tgz",
+			"integrity": "sha1-lUtdGTIcpDYJL6kPBtZ5hTH+gYQ="
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"requires": {
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"split": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+					"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+					"requires": {
+						"through": "2.3.8"
+					}
+				}
+			}
 		},
 		"execa": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
 			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -952,61 +1959,168 @@
 				"strip-eof": "1.0.0"
 			}
 		},
+		"exit-hook": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"express": {
+			"version": "4.16.3",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.2",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.3",
+				"qs": "6.5.1",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.1",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			}
+		},
 		"extend": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-			"dev": true
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
 		},
 		"external-editor": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-			"dev": true,
 			"requires": {
 				"chardet": "0.4.2",
 				"iconv-lite": "0.4.19",
 				"tmp": "0.0.33"
 			}
 		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				}
+			}
+		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		},
+		"fancy-log": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+			"requires": {
+				"ansi-gray": "0.1.1",
+				"color-support": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
 		},
 		"fast-deep-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-			"dev": true
+			"integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fibers": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fibers/-/fibers-2.0.0.tgz",
-			"integrity": "sha512-sLxo4rZVk7xLgAjb/6zEzHJfSALx6u6coN1z61XCOF7i6CyTdJawF4+RdpjCSeS8AP66eR2InScbYAz9RAVOgA==",
-			"dev": true
+			"integrity": "sha512-sLxo4rZVk7xLgAjb/6zEzHJfSALx6u6coN1z61XCOF7i6CyTdJawF4+RdpjCSeS8AP66eR2InScbYAz9RAVOgA=="
 		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5"
 			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
 			"integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-			"dev": true,
 			"requires": {
 				"glob": "5.0.15",
 				"minimatch": "2.0.10"
@@ -1016,7 +2130,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1029,67 +2142,203 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "1.1.8"
 					}
 				}
 			}
 		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "1.0.1",
+				"merge-descriptors": "1.0.1"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.4.0",
+				"unpipe": "1.0.0"
+			}
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+			"integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+			"requires": {
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-			"dev": true,
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.5",
 				"mime-types": "2.1.17"
 			}
 		},
+		"formatio": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+			"requires": {
+				"samsam": "1.3.0"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+		},
 		"fs-extra": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"jsonfile": "4.0.0",
 				"universalify": "0.1.1"
 			}
 		},
+		"fs-promise": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-1.0.0.tgz",
+			"integrity": "sha1-QkakzUVJfS7Vfm5LIhZ9OGSyNnk=",
+			"requires": {
+				"any-promise": "1.3.0",
+				"fs-extra": "1.0.0",
+				"mz": "2.7.0",
+				"thenify-all": "1.6.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+					"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"jsonfile": "2.4.0",
+						"klaw": "1.3.1"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"requires": {
+						"graceful-fs": "4.1.11"
+					}
+				}
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "1.2.0",
 				"console-control-strings": "1.1.0",
@@ -1104,14 +2353,12 @@
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-			"dev": true
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"meow": "3.7.0",
@@ -1123,35 +2370,62 @@
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-			"dev": true
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0"
+			}
+		},
+		"gh-got": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+			"requires": {
+				"got": "7.1.0",
+				"is-plain-obj": "1.1.0"
+			},
+			"dependencies": {
+				"got": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+					"requires": {
+						"decompress-response": "3.3.0",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-plain-obj": "1.1.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"isurl": "1.0.0",
+						"lowercase-keys": "1.0.0",
+						"p-cancelable": "0.3.0",
+						"p-timeout": "1.2.1",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"url-parse-lax": "1.0.0",
+						"url-to-options": "1.0.1"
+					}
+				}
 			}
 		},
 		"git-raw-commits": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.0.tgz",
 			"integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
-			"dev": true,
 			"requires": {
 				"dargs": "4.1.0",
 				"lodash.template": "4.4.0",
@@ -1164,7 +2438,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "1.0.0",
 				"pify": "2.3.0"
@@ -1174,7 +2447,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.0.tgz",
 			"integrity": "sha1-sVSDOmq1w2DArTsaqbjxLqBt6Rk=",
-			"dev": true,
 			"requires": {
 				"meow": "3.7.0",
 				"semver": "5.5.0"
@@ -1184,16 +2456,22 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "1.3.5"
+			}
+		},
+		"github-username": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+			"requires": {
+				"gh-got": "6.0.0"
 			}
 		},
 		"glob": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
@@ -1203,21 +2481,115 @@
 				"path-is-absolute": "1.0.1"
 			}
 		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
 		"glob-parent": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-			"dev": true,
 			"requires": {
 				"is-glob": "3.1.0",
 				"path-dirname": "1.0.2"
 			}
 		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "0.6.5",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"globals": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+			"integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA=="
+		},
 		"globby": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-			"dev": true,
 			"requires": {
 				"array-union": "1.0.2",
 				"glob": "7.1.2",
@@ -1226,11 +2598,18 @@
 				"pinkie-promise": "2.0.1"
 			}
 		},
+		"glogg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
 		"got": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-			"dev": true,
 			"requires": {
 				"create-error-class": "3.0.2",
 				"duplexer3": "0.1.4",
@@ -1248,14 +2627,183 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"grouped-queue": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
+			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"growl": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+			"integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
+		},
+		"gulp-license-check": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
+			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
+			"requires": {
+				"event-stream": "3.3.4",
+				"gulp-util": "3.0.8",
+				"through2": "2.0.3",
+				"vinyl-file": "2.0.0"
+			}
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"requires": {
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.2",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"dateformat": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"lodash.template": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+					"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+					"requires": {
+						"lodash._basecopy": "3.0.1",
+						"lodash._basetostring": "3.0.1",
+						"lodash._basevalues": "3.0.0",
+						"lodash._isiterateecall": "3.0.9",
+						"lodash._reinterpolate": "3.0.0",
+						"lodash.escape": "3.2.0",
+						"lodash.keys": "3.1.2",
+						"lodash.restparam": "3.6.1",
+						"lodash.templatesettings": "3.1.1"
+					}
+				},
+				"lodash.templatesettings": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+					"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+					"requires": {
+						"lodash._reinterpolate": "3.0.0",
+						"lodash.escape": "3.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"requires": {
+				"glogg": "1.0.1"
+			}
+		},
+		"gunzip-maybe": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+			"integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+			"requires": {
+				"browserify-zlib": "0.1.4",
+				"is-deflate": "1.0.0",
+				"is-gzip": "1.0.0",
+				"peek-stream": "1.1.3",
+				"pumpify": "1.4.0",
+				"through2": "2.0.3"
+			}
 		},
 		"handlebars": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
 			"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"optimist": "0.6.1",
@@ -1266,14 +2814,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"source-map": {
 					"version": "0.4.4",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"dev": true,
 					"requires": {
 						"amdefine": "1.0.1"
 					}
@@ -1283,14 +2829,12 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-			"dev": true,
 			"requires": {
 				"ajv": "5.4.0",
 				"har-schema": "2.0.0"
@@ -1300,7 +2844,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
 			"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "0.2.1"
 			},
@@ -1308,28 +2851,45 @@
 				"ansi-regex": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
-					"dev": true
+					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
 				}
 			}
 		},
 		"has-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-			"dev": true
+			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"has-symbol-support-x": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+		},
+		"has-to-string-tag-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"requires": {
+				"has-symbol-support-x": "1.4.2"
+			}
 		},
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"dev": true,
 			"requires": {
 				"boom": "4.3.1",
 				"cryptiles": "3.1.2",
@@ -1337,23 +2897,41 @@
 				"sntp": "2.1.0"
 			}
 		},
+		"he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+		},
 		"hoek": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-			"dev": true
+			"integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+		},
+		"homedir": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/homedir/-/homedir-0.6.0.tgz",
+			"integrity": "sha1-KyHbZr8Ipts4JJo+/1LX0YcGrx4="
 		},
 		"hosted-git-info": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-			"dev": true
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"requires": {
+				"depd": "1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0"
+			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"jsprim": "1.4.1",
@@ -1363,20 +2941,42 @@
 		"iconv-lite": {
 			"version": "0.4.19",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-			"dev": true
+			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+		},
+		"ietf-language-tag-regex": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/ietf-language-tag-regex/-/ietf-language-tag-regex-0.0.5.tgz",
+			"integrity": "sha1-gRM62z0ckpuP8fRyVEkK7no0Ys4=",
+			"requires": {
+				"xregexp": "3.2.0"
+			},
+			"dependencies": {
+				"xregexp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
+					"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+				}
+			}
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+		},
+		"immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"indent-string": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
 			"requires": {
 				"repeating": "2.0.1"
 			}
@@ -1385,7 +2985,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "1.4.0",
 				"wrappy": "1.0.2"
@@ -1394,20 +2993,17 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-			"dev": true
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inquirer": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "3.0.0",
 				"chalk": "2.3.0",
@@ -1428,14 +3024,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -1444,7 +3038,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -1454,20 +3047,17 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -1477,7 +3067,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -1486,36 +3075,41 @@
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
 				}
 			}
 		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-			"dev": true
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"ipaddr.js": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+			"integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-buffer": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-			"dev": true
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
 			"requires": {
 				"builtin-modules": "1.1.1"
 			}
@@ -1524,22 +3118,42 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-			"dev": true,
 			"requires": {
 				"ci-info": "1.1.2"
 			}
 		},
+		"is-deflate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+			"integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -1548,7 +3162,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "1.0.1"
 			}
@@ -1557,58 +3170,111 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-			"dev": true
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-			"dev": true
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-scoped": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+			"requires": {
+				"scoped-regex": "1.0.0"
+			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-			"dev": true
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY="
 		},
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
-			"dev": true,
 			"requires": {
 				"text-extensions": "1.7.0"
 			}
@@ -1616,38 +3282,90 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"requires": {
+				"abbrev": "1.0.9",
+				"async": "1.5.2",
+				"escodegen": "1.8.1",
+				"esprima": "2.7.3",
+				"glob": "5.0.15",
+				"handlebars": "4.0.10",
+				"js-yaml": "3.10.0",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"once": "1.4.0",
+				"resolve": "1.1.7",
+				"supports-color": "3.2.3",
+				"which": "1.3.0",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"requires": {
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
 		},
 		"istanbul-combine": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-combine/-/istanbul-combine-0.3.0.tgz",
 			"integrity": "sha1-VrLV5joiBZi23ErIrVcucV6ZV3M=",
-			"dev": true,
 			"requires": {
 				"glob": "5.0.15",
 				"istanbul": "0.3.22",
@@ -1658,14 +3376,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"escodegen": {
 					"version": "1.7.1",
 					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
 					"integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
-					"dev": true,
 					"requires": {
 						"esprima": "1.2.5",
 						"estraverse": "1.9.3",
@@ -1677,34 +3393,29 @@
 						"esprima": {
 							"version": "1.2.5",
 							"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-							"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
-							"dev": true
+							"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
 						}
 					}
 				},
 				"esprima": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
-					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
-					"dev": true
+					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw="
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-					"dev": true
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
 				},
 				"fast-levenshtein": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-					"dev": true
+					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
 				},
 				"glob": {
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -1716,14 +3427,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"istanbul": {
 					"version": "0.3.22",
 					"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
 					"integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
-					"dev": true,
 					"requires": {
 						"abbrev": "1.0.9",
 						"async": "1.5.2",
@@ -1745,7 +3454,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
 					"integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-					"dev": true,
 					"requires": {
 						"prelude-ls": "1.1.2",
 						"type-check": "0.3.2"
@@ -1754,14 +3462,12 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"optionator": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
 					"integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-					"dev": true,
 					"requires": {
 						"deep-is": "0.1.3",
 						"fast-levenshtein": "1.0.7",
@@ -1774,8 +3480,7 @@
 						"wordwrap": {
 							"version": "0.0.3",
 							"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-							"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-							"dev": true
+							"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 						}
 					}
 				},
@@ -1783,7 +3488,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": "1.0.1"
@@ -1793,7 +3497,6 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "1.0.0"
 					}
@@ -1801,22 +3504,19 @@
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-					"dev": true
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 				}
 			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
-			"dev": true
+			"integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
 		},
 		"istanbul-merge": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-merge/-/istanbul-merge-1.1.1.tgz",
 			"integrity": "sha1-db5kNDbU3nI+A6lNHKX1+ZSwvXI=",
-			"dev": true,
 			"requires": {
 				"foreach": "2.0.5",
 				"glob": "7.1.2",
@@ -1828,14 +3528,12 @@
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -1846,7 +3544,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
 					"requires": {
 						"lcid": "1.0.0"
 					}
@@ -1854,20 +3551,17 @@
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"window-size": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-					"dev": true
+					"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 				},
 				"yargs": {
 					"version": "4.8.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"dev": true,
 					"requires": {
 						"cliui": "3.2.0",
 						"decamelize": "1.2.0",
@@ -1889,7 +3583,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"dev": true,
 					"requires": {
 						"camelcase": "3.0.0",
 						"lodash.assign": "4.2.0"
@@ -1897,11 +3590,34 @@
 				}
 			}
 		},
+		"istextorbinary": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+			"requires": {
+				"binaryextensions": "2.1.1",
+				"editions": "1.3.4",
+				"textextensions": "2.2.0"
+			}
+		},
+		"isurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"requires": {
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
+			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
 		"js-yaml": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-			"dev": true,
 			"requires": {
 				"argparse": "1.0.9",
 				"esprima": "4.0.0"
@@ -1910,8 +3626,7 @@
 				"esprima": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-					"dev": true
+					"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 				}
 			}
 		},
@@ -1919,7 +3634,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
 			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
-			"dev": true,
 			"requires": {
 				"xmlcreate": "1.0.2"
 			}
@@ -1928,14 +3642,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true,
 			"optional": true
 		},
 		"jsdoc": {
 			"version": "3.5.5",
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
 			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
-			"dev": true,
 			"requires": {
 				"babylon": "7.0.0-beta.19",
 				"bluebird": "3.5.1",
@@ -1955,7 +3667,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
 					"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11"
 					}
@@ -1966,7 +3677,6 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/jsdoc-sphinx/-/jsdoc-sphinx-0.0.6.tgz",
 			"integrity": "sha1-7rerF8QgLEYqBcWwmlb3cQiXvzE=",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"canonical-path": "0.0.2",
@@ -1980,61 +3690,80 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-					"dev": true
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				}
 			}
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
-			"dev": true
+			"integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-			"dev": true
+			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json3": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"json5": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+			"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11"
 			}
 		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -2042,27 +3771,98 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jszip": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+			"integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+			"requires": {
+				"core-js": "2.3.0",
+				"es6-promise": "3.0.2",
+				"lie": "3.1.1",
+				"pako": "1.0.6",
+				"readable-stream": "2.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "0.10.31",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"jura-compiler": {
+			"version": "0.0.19",
+			"resolved": "https://registry.npmjs.org/jura-compiler/-/jura-compiler-0.0.19.tgz",
+			"integrity": "sha512-8hf2ySVJJTmx+UQWbJnTadjCOiv4pRUEB8APpX49NsLsrM4v5yeev+1yskTMYbsS+XjR9d8zeSrgnE5GXs3XBQ==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"yargs": "9.0.1"
+			}
+		},
+		"jura-engine": {
+			"version": "0.0.19",
+			"resolved": "https://registry.npmjs.org/jura-engine/-/jura-engine-0.0.19.tgz",
+			"integrity": "sha512-efzDC2k5veruuLywvjYvXZp2S+BuJJqjXImpZObLH4L6RLZ8+Ga5jvt0+3aP53eFzMeJ7COGT6oNcx5IAowYQQ==",
+			"requires": {
+				"composer-common": "0.17.4",
+				"jura-compiler": "0.0.19",
+				"moment": "2.20.1",
+				"vm2": "3.5.2",
+				"yargs": "9.0.1"
+			}
+		},
+		"just-extend": {
+			"version": "1.1.27",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "1.1.5"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"requires": {
+				"graceful-fs": "4.1.11"
 			}
 		},
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"dev": true,
 			"optional": true
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
 		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -2070,14 +3870,17 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-			"dev": true
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+		},
+		"left-pad": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+			"integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
 		},
 		"lerna": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-2.8.0.tgz",
 			"integrity": "sha512-ts8TyZAm5tJgWjQCvvuxyKJyhvCnXCOo/OppMoq96U9kvmPTf6URDqmsVYQWBVvnLpiZroX1VWhMZisFrbTalA==",
-			"dev": true,
 			"requires": {
 				"async": "1.5.2",
 				"chalk": "2.3.0",
@@ -2123,14 +3926,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"ansi-styles": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
 					"requires": {
 						"color-convert": "1.9.1"
 					}
@@ -2138,14 +3939,12 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"chalk": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "3.2.0",
 						"escape-string-regexp": "1.0.5",
@@ -2156,7 +3955,6 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
@@ -2167,7 +3965,6 @@
 							"version": "1.0.2",
 							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
 							"requires": {
 								"code-point-at": "1.1.0",
 								"is-fullwidth-code-point": "1.0.0",
@@ -2179,14 +3976,12 @@
 				"has-flag": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-					"dev": true
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 				},
 				"path-type": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
 					"requires": {
 						"pify": "2.3.0"
 					}
@@ -2195,7 +3990,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-					"dev": true,
 					"requires": {
 						"find-up": "2.1.0",
 						"read-pkg": "2.0.0"
@@ -2205,7 +3999,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-							"dev": true,
 							"requires": {
 								"graceful-fs": "4.1.11",
 								"parse-json": "2.2.0",
@@ -2217,7 +4010,6 @@
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-							"dev": true,
 							"requires": {
 								"load-json-file": "2.0.0",
 								"normalize-package-data": "2.4.0",
@@ -2230,7 +4022,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "2.0.0",
 						"strip-ansi": "4.0.0"
@@ -2239,14 +4030,12 @@
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
 							"requires": {
 								"ansi-regex": "3.0.0"
 							}
@@ -2256,14 +4045,12 @@
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "2.0.0"
 					}
@@ -2272,7 +4059,6 @@
 					"version": "8.0.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
 					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"dev": true,
 					"requires": {
 						"camelcase": "4.1.0",
 						"cliui": "3.2.0",
@@ -2291,11 +4077,31 @@
 				}
 			}
 		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"license-check": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
+			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
+			"requires": {
+				"gulp-license-check": "1.2.1",
+				"gulp-util": "3.0.8",
+				"istanbul": "0.4.5",
+				"pkg-conf": "1.1.3",
+				"vinyl-fs": "2.4.4"
+			}
+		},
 		"licensecheck": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/licensecheck/-/licensecheck-1.3.0.tgz",
 			"integrity": "sha1-ouuJ7fqZ0ndBZ1LWp9Mp+p+wz9Q=",
-			"dev": true,
 			"requires": {
 				"colors": "1.1.2",
 				"markdown": "0.5.0",
@@ -2304,11 +4110,18 @@
 				"treeify": "1.0.1"
 			}
 		},
+		"lie": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+			"integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+			"requires": {
+				"immediate": "3.0.6"
+			}
+		},
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "4.0.0",
@@ -2320,7 +4133,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
 					"requires": {
 						"error-ex": "1.3.1",
 						"json-parse-better-errors": "1.0.1"
@@ -2329,14 +4141,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 				}
 			}
 		},
@@ -2344,7 +4154,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -2353,26 +4162,129 @@
 		"lodash": {
 			"version": "4.17.5",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-			"dev": true
+			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+		},
+		"lodash._basecreate": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+			"integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+		},
+		"lodash.create": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+			"requires": {
+				"lodash._baseassign": "3.2.0",
+				"lodash._basecreate": "3.0.3",
+				"lodash._isiterateecall": "3.0.9"
+			}
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "3.0.0",
 				"lodash.templatesettings": "4.1.0"
@@ -2382,7 +4294,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "3.0.0"
 			}
@@ -2390,20 +4301,54 @@
 		"log-driver": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-			"dev": true
+			"integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY="
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"requires": {
+				"chalk": "2.3.2"
+			}
+		},
+		"lolex": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+			"integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+		},
+		"long": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+			"optional": true
 		},
 		"longest": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"lorem-ipsum": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-1.0.4.tgz",
+			"integrity": "sha1-MLcqOx4ZH1UGKvjH36spGuT72RI=",
+			"requires": {
+				"optimist": "0.3.7"
+			},
+			"dependencies": {
+				"optimist": {
+					"version": "0.3.7",
+					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+					"requires": {
+						"wordwrap": "0.0.3"
+					}
+				}
+			}
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "0.4.1",
 				"signal-exit": "3.0.2"
@@ -2412,14 +4357,12 @@
 		"lowercase-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-			"dev": true
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
 		},
 		"lru-cache": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "1.0.2",
 				"yallist": "2.1.2"
@@ -2429,7 +4372,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
 			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-			"dev": true,
 			"requires": {
 				"pify": "3.0.0"
 			},
@@ -2437,22 +4379,24 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
 		"map-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-			"dev": true
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
 		},
 		"markdown": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
 			"integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
-			"dev": true,
 			"requires": {
 				"nopt": "2.1.2"
 			},
@@ -2461,7 +4405,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
 					"integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-					"dev": true,
 					"requires": {
 						"abbrev": "1.0.9"
 					}
@@ -2471,23 +4414,94 @@
 		"marked": {
 			"version": "0.3.12",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-			"integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
-			"dev": true
+			"integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
+			}
+		},
+		"mem-fs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
+			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+			"requires": {
+				"through2": "2.0.3",
+				"vinyl": "1.2.0",
+				"vinyl-file": "2.0.0"
+			},
+			"dependencies": {
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"mem-fs-editor": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
+			"integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+			"requires": {
+				"commondir": "1.0.1",
+				"deep-extend": "0.4.2",
+				"ejs": "2.5.8",
+				"glob": "7.1.2",
+				"globby": "6.1.0",
+				"mkdirp": "0.5.1",
+				"multimatch": "2.1.0",
+				"rimraf": "2.6.2",
+				"through2": "2.0.3",
+				"vinyl": "2.1.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+				},
+				"clone-stats": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+				},
+				"replace-ext": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+				},
+				"vinyl": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+					"requires": {
+						"clone": "2.1.2",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.1.2",
+						"remove-trailing-separator": "1.1.0",
+						"replace-ext": "1.0.0"
+					}
+				}
 			}
 		},
 		"meow": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "2.1.0",
 				"decamelize": "1.2.0",
@@ -2504,22 +4518,77 @@
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
 		},
 		"mime-db": {
 			"version": "1.30.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-			"dev": true
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
 		},
 		"mime-types": {
 			"version": "2.1.17",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.30.0"
 			}
@@ -2527,14 +4596,17 @@
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"mimic-response": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+			"integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "1.1.8"
 			}
@@ -2542,53 +4614,279 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
 		},
+		"mocha": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+			"integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+			"requires": {
+				"browser-stdout": "1.3.0",
+				"commander": "2.9.0",
+				"debug": "2.6.8",
+				"diff": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.1",
+				"growl": "1.9.2",
+				"he": "1.1.1",
+				"json3": "3.3.2",
+				"lodash.create": "3.1.1",
+				"mkdirp": "0.5.1",
+				"supports-color": "3.1.2"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+					"requires": {
+						"graceful-readlink": "1.0.1"
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+					"requires": {
+						"has-flag": "1.0.0"
+					}
+				}
+			}
+		},
+		"mocha-lcov-reporter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+			"integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q="
+		},
+		"mockery": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+			"integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+		},
 		"modify-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-			"integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
-			"dev": true
+			"integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI="
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
 		},
 		"moment": {
 			"version": "2.20.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
-			"dev": true
+			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+		},
+		"moo": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"requires": {
+				"duplexer2": "0.0.2"
+			}
 		},
 		"mustache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
-			"integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
-			"dev": true
+			"integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
 		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"requires": {
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
+			}
 		},
 		"nan": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-			"dev": true
+			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+		},
+		"native-promise-only": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"nearley": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.13.0.tgz",
+			"integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
+			"requires": {
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
+				"randexp": "0.4.6",
+				"semver": "5.5.0"
+			}
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"nise": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+			"integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"just-extend": "1.1.27",
+				"lolex": "2.3.2",
+				"path-to-regexp": "1.7.0",
+				"text-encoding": "0.6.4"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"path-to-regexp": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+					"requires": {
+						"isarray": "0.0.1"
+					}
+				}
+			}
+		},
+		"node-nailgun-client": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.0.tgz",
+			"integrity": "sha1-tkJNsGA3gaGT82c4Xi1hXKbfILI=",
+			"requires": {
+				"commander": "2.15.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				}
+			}
+		},
+		"node-nailgun-server": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.3.tgz",
+			"integrity": "sha1-plCRjkhhXI18TSOT22cxblrQEvE=",
+			"requires": {
+				"commander": "2.15.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				}
+			}
+		},
+		"node-plantuml": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.5.0.tgz",
+			"integrity": "sha1-A8LthW5rJyxxShVoRTp0fCZv3B8=",
+			"requires": {
+				"commander": "2.15.1",
+				"node-nailgun-client": "0.1.0",
+				"node-nailgun-server": "0.1.3",
+				"plantuml-encoder": "1.2.5"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				}
+			}
+		},
+		"nomnom": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+			"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+			"requires": {
+				"colors": "0.5.1",
+				"underscore": "1.4.4"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+					"integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+				},
+				"underscore": {
+					"version": "1.4.4",
+					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+					"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+				}
+			}
 		},
 		"nopt": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
 			"requires": {
 				"abbrev": "1.0.9"
 			}
@@ -2597,7 +4895,6 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "2.5.0",
 				"is-builtin-module": "1.0.0",
@@ -2605,11 +4902,18 @@
 				"validate-npm-package-license": "3.0.1"
 			}
 		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -2618,7 +4922,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "1.1.4",
 				"console-control-strings": "1.1.0",
@@ -2629,26 +4932,2463 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"nyc": {
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
+			"integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+			"requires": {
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.1",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
+				"glob": "7.1.2",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.3",
+				"istanbul-lib-source-maps": "1.2.3",
+				"istanbul-reports": "1.3.0",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.1.0",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.2",
+				"signal-exit": "3.0.2",
+				"spawn-wrap": "1.4.2",
+				"test-exclude": "4.2.1",
+				"yargs": "11.1.0",
+				"yargs-parser": "8.1.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2",
+						"longest": "1.0.1",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "1.1.0"
+					}
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"chalk": "1.1.3",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.1",
+					"bundled": true,
+					"requires": {
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"detect-indent": "4.0.0",
+						"jsesc": "1.3.0",
+						"lodash": "4.17.5",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"core-js": "2.5.3",
+						"regenerator-runtime": "0.11.1"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"lodash": "4.17.5"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-code-frame": "6.26.0",
+						"babel-messages": "6.23.0",
+						"babel-runtime": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"debug": "2.6.9",
+						"globals": "9.18.0",
+						"invariant": "2.2.3",
+						"lodash": "4.17.5"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "6.26.0",
+						"esutils": "2.0.2",
+						"lodash": "4.17.5",
+						"to-fast-properties": "1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "1.0.1",
+						"class-utils": "0.3.6",
+						"component-emitter": "1.2.1",
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"mixin-deep": "1.3.1",
+						"pascalcase": "0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "1.8.5",
+					"bundled": true,
+					"requires": {
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "1.0.0",
+						"component-emitter": "1.2.1",
+						"get-value": "2.0.6",
+						"has-value": "1.0.0",
+						"isobject": "3.0.1",
+						"set-value": "2.0.0",
+						"to-object-path": "0.3.0",
+						"union-value": "1.0.0",
+						"unset-value": "1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "1.3.0",
+						"mkdirp": "0.5.1",
+						"write-file-atomic": "1.3.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4",
+						"lazy-cache": "1.0.4"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"define-property": "0.2.5",
+						"isobject": "3.0.1",
+						"static-extend": "0.1.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "1.0.0",
+						"object-visit": "1.0.1"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"core-js": {
+					"version": "2.5.3",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "4.1.2",
+						"which": "1.3.0"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "1.0.2",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"repeating": "2.0.1"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "4.1.2",
+								"shebang-command": "1.2.0",
+								"which": "1.3.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"is-posix-bracket": "0.1.1"
+					}
+				},
+				"expand-range": {
+					"version": "1.8.2",
+					"bundled": true,
+					"requires": {
+						"fill-range": "2.2.3"
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "0.3.2",
+					"bundled": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"filename-regex": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"fill-range": {
+					"version": "2.2.3",
+					"bundled": true,
+					"requires": {
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"for-own": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"signal-exit": "3.0.2"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"glob-base": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"glob-parent": "2.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "1.5.2",
+						"optimist": "0.6.1",
+						"source-map": "0.4.4",
+						"uglify-js": "2.8.29"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "2.0.6",
+						"has-values": "1.0.0",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invariant": {
+					"version": "2.2.3",
+					"bundled": true,
+					"requires": {
+						"loose-envify": "1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "1.1.1"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"is-dotfile": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"is-equal-shallow": {
+					"version": "0.1.3",
+					"bundled": true,
+					"requires": {
+						"is-primitive": "2.0.0"
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				},
+				"is-number": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"is-posix-bracket": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-primitive": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"isarray": "1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"bundled": true,
+					"requires": {
+						"babel-generator": "6.26.1",
+						"babel-template": "6.26.0",
+						"babel-traverse": "6.26.0",
+						"babel-types": "6.26.0",
+						"babylon": "6.18.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"semver": "5.5.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.3",
+					"bundled": true,
+					"requires": {
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"handlebars": "4.0.11"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.5",
+					"bundled": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"js-tokens": "3.0.2"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "1.0.1"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "1.2.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "2.3.11",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "1.0.2",
+						"is-extendable": "1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"fragment-cache": "0.2.1",
+						"is-odd": "2.0.0",
+						"is-windows": "1.0.2",
+						"kind-of": "6.0.2",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "2.6.0",
+						"is-builtin-module": "1.0.0",
+						"semver": "5.5.0",
+						"validate-npm-package-license": "3.0.3"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"remove-trailing-separator": "1.1.0"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "2.0.1"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "0.1.1",
+						"define-property": "0.2.5",
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"object.omit": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"for-own": "0.1.5",
+						"is-extendable": "0.1.1"
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8",
+						"wordwrap": "0.0.3"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "1.2.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-glob": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"glob-base": "0.3.0",
+						"is-dotfile": "1.0.3",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "1.3.1"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "2.0.4"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "1.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"preserve": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"randomatic": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"kind-of": "4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true
+				},
+				"regex-cache": {
+					"version": "0.4.4",
+					"bundled": true,
+					"requires": {
+						"is-equal-shallow": "0.1.3"
+					}
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"remove-trailing-separator": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"is-finite": "1.0.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "0.1.4"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "0.1.15"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"split-string": "3.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "0.11.2",
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"map-cache": "0.2.2",
+						"source-map": "0.5.7",
+						"source-map-resolve": "0.5.1",
+						"use": "3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "1.0.0",
+						"isobject": "3.0.1",
+						"snapdragon-util": "3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "1.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"atob": "2.0.3",
+						"decode-uri-component": "0.2.0",
+						"resolve-url": "0.2.1",
+						"source-map-url": "0.4.0",
+						"urix": "0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.2",
+						"signal-exit": "3.0.2",
+						"which": "1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "3.0.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "2.1.0",
+						"spdx-license-ids": "3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "3.0.2"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "0.2.5",
+						"object-copy": "0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "0.1.6"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "0.2.1"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "1.0.1",
+						"micromatch": "3.1.9",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"braces": {
+							"version": "2.3.1",
+							"bundled": true,
+							"requires": {
+								"arr-flatten": "1.1.0",
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"extend-shallow": "2.0.1",
+								"fill-range": "4.0.0",
+								"isobject": "3.0.1",
+								"kind-of": "6.0.2",
+								"repeat-element": "1.1.2",
+								"snapdragon": "0.8.2",
+								"snapdragon-node": "2.1.1",
+								"split-string": "3.1.0",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"bundled": true,
+							"requires": {
+								"debug": "2.6.9",
+								"define-property": "0.2.5",
+								"extend-shallow": "2.0.1",
+								"posix-character-classes": "0.1.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "0.1.6"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"is-accessor-descriptor": "0.1.6",
+										"is-data-descriptor": "0.1.4",
+										"kind-of": "5.1.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"array-unique": "0.3.2",
+								"define-property": "1.0.0",
+								"expand-brackets": "2.1.4",
+								"extend-shallow": "2.0.1",
+								"fragment-cache": "0.2.1",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "1.0.2"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-number": "3.0.0",
+								"repeat-string": "1.6.1",
+								"to-regex-range": "2.1.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "0.1.1"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "1.1.6"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						},
+						"micromatch": {
+							"version": "3.1.9",
+							"bundled": true,
+							"requires": {
+								"arr-diff": "4.0.0",
+								"array-unique": "0.3.2",
+								"braces": "2.3.1",
+								"define-property": "2.0.2",
+								"extend-shallow": "3.0.2",
+								"extglob": "2.0.4",
+								"fragment-cache": "0.2.1",
+								"kind-of": "6.0.2",
+								"nanomatch": "1.2.9",
+								"object.pick": "1.3.0",
+								"regex-not": "1.0.2",
+								"snapdragon": "0.8.2",
+								"to-regex": "3.0.2"
+							}
+						}
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"regex-not": "1.0.2",
+						"safe-regex": "1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "3.2.2"
+							}
+						}
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "1.2.1",
+								"cliui": "2.1.0",
+								"decamelize": "1.2.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "3.1.0",
+						"get-value": "2.0.6",
+						"is-extendable": "0.1.1",
+						"set-value": "0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "0.1.1"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "2.0.1",
+								"is-extendable": "0.1.1",
+								"is-plain-object": "2.0.4",
+								"to-object-path": "0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "0.3.1",
+						"isobject": "3.0.1"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "2.0.6",
+								"has-values": "0.1.4",
+								"isobject": "2.1.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "3.0.0",
+						"spdx-expression-parse": "3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "1.0.1"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "2.1.1",
+								"strip-ansi": "4.0.0",
+								"wrap-ansi": "2.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
 		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-			"dev": true
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1.0.2"
 			}
@@ -2657,7 +7397,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "1.2.0"
 			}
@@ -2666,7 +7405,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8",
 				"wordwrap": "0.0.3"
@@ -2675,16 +7413,48 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -2695,7 +7465,6 @@
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "5.1.0",
 						"get-stream": "3.0.0",
@@ -2708,23 +7477,30 @@
 				}
 			}
 		},
+		"os-shim": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+			"integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
+		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"p-cancelable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-			"dev": true,
 			"requires": {
 				"p-try": "1.0.0"
 			}
@@ -2733,22 +7509,27 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-			"dev": true,
 			"requires": {
 				"p-limit": "1.2.0"
+			}
+		},
+		"p-timeout": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+			"requires": {
+				"p-finally": "1.0.0"
 			}
 		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-			"dev": true
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"package-json": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-			"dev": true,
 			"requires": {
 				"got": "6.7.1",
 				"registry-auth-token": "3.3.2",
@@ -2756,191 +7537,156 @@
 				"semver": "5.5.0"
 			}
 		},
+		"pad-component": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
+			"integrity": "sha1-rR8izhvw/cDW3dkIrxfzUaQEuKw="
+		},
+		"pako": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+			"integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+		},
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
 		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
 			"requires": {
 				"error-ex": "1.3.1"
 			}
 		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"path-type": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"pify": "2.3.0",
 				"pinkie-promise": "2.0.1"
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"peek-stream": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+			"integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+			"requires": {
+				"buffer-from": "1.0.0",
+				"duplexify": "3.5.4",
+				"through2": "2.0.3"
+			}
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 		},
 		"pinkie": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
 		},
 		"pinkie-promise": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
 			"requires": {
 				"pinkie": "2.0.4"
 			}
 		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
-		},
-		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-			"dev": true
-		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
-		},
-		"q": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-			"integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
-			"dev": true
-		},
-		"qs": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-			"dev": true
-		},
-		"rc": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-			"integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
-			"dev": true,
-			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
-			}
-		},
-		"read-cmd-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
-		},
-		"read-pkg": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-			"dev": true,
-			"requires": {
-				"load-json-file": "4.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "3.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
-			}
-		},
-		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
+		"pkg-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
 			"requires": {
 				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"load-json-file": "1.1.0",
+				"object-assign": "4.1.1",
+				"symbol": "0.2.3"
 			},
 			"dependencies": {
 				"find-up": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "2.1.0",
 						"pinkie-promise": "2.0.1"
@@ -2950,7 +7696,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "4.1.11",
 						"parse-json": "2.2.0",
@@ -2963,7 +7708,336 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
+					"requires": {
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"plantuml-encoder": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.2.5.tgz",
+			"integrity": "sha512-viV7Sz+BJNX/sC3iyebh2VfLyAZKuu3+JuBs2ISms8+zoTGwPqwk3/WEDw/zROmGAJ/xD4sNd8zsBw/YmTo7ng==",
+			"requires": {
+				"pako": "1.0.3",
+				"utf8-bytes": "0.0.1"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz",
+					"integrity": "sha1-X1FbDGci4ZgpIK6ABerLC3ynPM8="
+				}
+			}
+		},
+		"pluralize": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-bytes": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+			"integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
+		"progress": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+		},
+		"promise-polyfill": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+			"integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
+		},
+		"protobufjs": {
+			"version": "6.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.6.3.tgz",
+			"integrity": "sha1-7nOI3ZRegQznONy2W/0J+keqSZM=",
+			"requires": {
+				"@protobufjs/aspromise": "1.1.2",
+				"@protobufjs/base64": "1.1.2",
+				"@protobufjs/codegen": "1.0.8",
+				"@protobufjs/eventemitter": "1.1.0",
+				"@protobufjs/fetch": "1.1.0",
+				"@protobufjs/inquire": "1.1.0",
+				"@protobufjs/path": "1.1.2",
+				"@protobufjs/pool": "1.1.0",
+				"@protobufjs/utf8": "1.1.0",
+				"@types/long": "3.0.32",
+				"@types/node": "7.0.4",
+				"long": "3.2.0"
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.6.0"
+			}
+		},
+		"proxyquire": {
+			"version": "1.7.11",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.7.11.tgz",
+			"integrity": "sha1-E7SU6x5x+yHMPr42meY3077Br54=",
+			"requires": {
+				"fill-keys": "1.0.2",
+				"module-not-found-error": "1.0.1",
+				"resolve": "1.1.7"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"pump": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"requires": {
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
+			}
+		},
+		"pumpify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"requires": {
+				"duplexify": "3.5.4",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+			"integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+		},
+		"q": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+			"integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+		},
+		"qs": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "0.1.15"
+			}
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.5"
+					}
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+			"integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.2",
+				"iconv-lite": "0.4.19",
+				"unpipe": "1.0.0"
+			},
+			"dependencies": {
+				"depd": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+					"integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+				},
+				"http-errors": {
+					"version": "1.6.2",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+					"integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+					"requires": {
+						"depd": "1.1.1",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.0.3",
+						"statuses": "1.4.0"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+					"integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+				}
+			}
+		},
+		"rc": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+			"integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"read-chunk": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-2.1.0.tgz",
+			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
+			"requires": {
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"read-cmd-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+			"requires": {
+				"graceful-fs": "4.1.11"
+			}
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"requires": {
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"requires": {
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
 						"pinkie-promise": "2.0.1"
 					}
@@ -2972,7 +8046,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "1.1.0",
 						"normalize-package-data": "2.4.0",
@@ -2983,7 +8056,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "0.2.1"
 					}
@@ -2994,7 +8066,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
@@ -3005,21 +8076,40 @@
 				"util-deprecate": "1.0.2"
 			}
 		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"requires": {
+				"resolve": "1.1.7"
+			}
+		},
 		"redent": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true,
 			"requires": {
 				"indent-string": "2.1.0",
 				"strip-indent": "1.0.1"
 			}
 		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regexpp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
+		},
 		"registry-auth-token": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
 			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"dev": true,
 			"requires": {
 				"rc": "1.2.5",
 				"safe-buffer": "5.1.1"
@@ -3029,31 +8119,42 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"dev": true,
 			"requires": {
 				"rc": "1.2.5"
 			}
 		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "1.0.2"
 			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
 		"request": {
 			"version": "2.83.0",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "0.7.0",
 				"aws4": "1.6.0",
@@ -3079,23 +8180,47 @@
 				"uuid": "3.1.0"
 			}
 		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "4.17.5"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.3"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			}
 		},
 		"requizzle": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
 			"integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
-			"dev": true,
 			"requires": {
 				"underscore": "1.6.0"
 			},
@@ -3103,32 +8228,38 @@
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-					"dev": true
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
 			}
 		},
 		"resolve": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-			"dev": true
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+		},
+		"resolve-from": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
 		},
 		"restore-cursor": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "2.0.1",
 				"signal-exit": "3.0.2"
 			}
 		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"align-text": "0.1.4"
@@ -3138,7 +8269,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "7.1.2"
 			}
@@ -3147,7 +8277,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "2.1.0"
 			}
@@ -3155,20 +8284,17 @@
 		"rx": {
 			"version": "2.3.24",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
-			"integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
-			"dev": true
+			"integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc="
 		},
 		"rx-lite": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
 		},
 		"rx-lite-aggregates": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
 			"requires": {
 				"rx-lite": "4.0.8"
 			}
@@ -3176,26 +8302,68 @@
 		"safe-buffer": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-			"dev": true
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"samsam": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+		},
+		"scoped-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
 		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.3",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"requires": {
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.2"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -3203,32 +8371,86 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shelljs": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+			"requires": {
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"sinon": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+			"integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+			"requires": {
+				"@sinonjs/formatio": "2.0.0",
+				"diff": "3.2.0",
+				"lodash.get": "4.4.2",
+				"lolex": "2.3.2",
+				"nise": "1.3.2",
+				"supports-color": "5.3.0",
+				"type-detect": "4.0.8"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+				}
+			}
 		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-			"dev": true
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"sleep-promise": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-2.0.0.tgz",
-			"integrity": "sha1-5+eY3+VsBE2oWILXbSKpmARmPEE=",
-			"dev": true
+			"integrity": "sha1-5+eY3+VsBE2oWILXbSKpmARmPEE="
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				}
+			}
 		},
 		"sntp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"dev": true,
 			"requires": {
 				"hoek": "4.2.0"
 			}
@@ -3237,7 +8459,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "1.1.0"
 			}
@@ -3246,14 +8467,12 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true,
 			"optional": true
 		},
 		"source-map-support": {
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
 			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
-			"dev": true,
 			"requires": {
 				"source-map": "0.6.1"
 			},
@@ -3261,22 +8480,33 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
-			"dev": true
+			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
+		},
+		"spawn-sync": {
+			"version": "1.0.15",
+			"resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+			"integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+			"requires": {
+				"concat-stream": "1.6.0",
+				"os-shim": "0.1.3"
+			}
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"dev": true,
 			"requires": {
 				"spdx-license-ids": "1.2.2"
 			}
@@ -3284,26 +8514,22 @@
 		"spdx-expression-parse": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-			"dev": true
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
 		},
 		"spdx-license-ids": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-			"dev": true
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
 		},
 		"spdx-license-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz",
-			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0=",
-			"dev": true
+			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0="
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2.3.8"
 			}
@@ -3312,7 +8538,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "2.0.3"
 			}
@@ -3320,14 +8545,12 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-			"dev": true,
 			"requires": {
 				"asn1": "0.2.3",
 				"assert-plus": "1.0.0",
@@ -3339,11 +8562,56 @@
 				"tweetnacl": "0.14.5"
 			}
 		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"requires": {
+				"duplexer": "0.1.1"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"stream-to-string": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
+			"integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+			"requires": {
+				"promise-polyfill": "1.1.6"
+			}
+		},
+		"streamifier": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+			"integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8="
+		},
+		"string-template": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+			"integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
 			"requires": {
 				"code-point-at": "1.1.0",
 				"is-fullwidth-code-point": "1.0.0",
@@ -3354,7 +8622,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -3362,14 +8629,12 @@
 		"stringstream": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-			"dev": true
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -3378,22 +8643,28 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
 			"requires": {
 				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"requires": {
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
 			"requires": {
 				"get-stdin": "4.0.1"
 			}
@@ -3401,14 +8672,12 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strong-log-transformer": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
 			"integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
-			"dev": true,
 			"requires": {
 				"byline": "5.0.0",
 				"duplexer": "0.1.1",
@@ -3420,8 +8689,7 @@
 				"minimist": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
-					"dev": true
+					"integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
 				}
 			}
 		},
@@ -3429,37 +8697,144 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 			"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-			"dev": true,
 			"requires": {
 				"has-flag": "1.0.0"
 			}
+		},
+		"symbol": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
 		},
 		"sync": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/sync/-/sync-0.2.5.tgz",
 			"integrity": "sha1-ORC7m2ar7lZULi5w8M5UkDElLfY=",
-			"dev": true,
 			"requires": {
 				"fibers": "2.0.0"
+			}
+		},
+		"table": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+			"requires": {
+				"ajv": "5.4.0",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.2",
+				"lodash": "4.17.5",
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
 			}
 		},
 		"taffydb": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-			"dev": true
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+		},
+		"taketalk": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
+			"integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
+			"requires": {
+				"get-stdin": "4.0.1",
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"tar-fs": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+			"integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+			"requires": {
+				"chownr": "1.0.1",
+				"mkdirp": "0.5.1",
+				"pump": "1.0.3",
+				"tar-stream": "1.5.5"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"requires": {
+				"bl": "1.2.2",
+				"end-of-stream": "1.4.1",
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"temp": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+			"requires": {
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.2.8",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+					"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+				}
+			}
 		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"is-stream": "1.1.0",
@@ -3472,8 +8847,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -3481,7 +8855,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
 			"integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2",
 				"uuid": "2.0.3"
@@ -3490,53 +8863,108 @@
 				"uuid": {
 					"version": "2.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-					"dev": true
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
 				}
 			}
+		},
+		"text-encoding": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
 		"text-extensions": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
-			"dev": true
+			"integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg=="
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"textextensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
+			"integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+		},
+		"thenify": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
+			"integrity": "sha1-JR/RyAr/blz1fLF5qx/LckJpvRE=",
+			"requires": {
+				"any-promise": "1.3.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+			"requires": {
+				"thenify": "3.2.1"
+			}
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "2.3.3",
 				"xtend": "4.0.1"
 			}
 		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-			"dev": true
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tmp-promise": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.0.4.tgz",
+			"integrity": "sha512-76r7LZhAvRJ3kLD/xrPSEGb3aq0tirzMLJKhcchKSkQIiEgXB+RouC0ygReuZX+oiA64taGo+j+1gHTKSG8/Mg==",
+			"requires": {
+				"bluebird": "3.5.1",
+				"tmp": "0.0.33"
+			}
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"requires": {
+				"extend-shallow": "2.0.1"
 			}
 		},
 		"tough-cookie": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-			"dev": true,
 			"requires": {
 				"punycode": "1.4.1"
 			},
@@ -3544,40 +8972,34 @@
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				}
 			}
 		},
 		"tree-kill": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
-			"dev": true
+			"integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
 		},
 		"treeify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.0.1.tgz",
-			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8=",
-			"dev": true
+			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8="
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.1"
 			}
@@ -3586,29 +9008,54 @@
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true,
 			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+			"integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.18"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.33.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+					"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+				},
+				"mime-types": {
+					"version": "2.1.18",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+					"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+					"requires": {
+						"mime-db": "1.33.0"
+					}
+				}
 			}
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"uglify-js": {
 			"version": "2.8.29",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"source-map": "0.5.7",
@@ -3620,14 +9067,12 @@
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-					"dev": true,
 					"optional": true
 				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"camelcase": "1.2.1",
@@ -3642,20 +9087,17 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"dev": true,
 			"optional": true
 		},
 		"underscore": {
 			"version": "1.8.3",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-			"dev": true
+			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 		},
 		"underscore-contrib": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
 			"integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-			"dev": true,
 			"requires": {
 				"underscore": "1.6.0"
 			},
@@ -3663,70 +9105,211 @@
 				"underscore": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-					"dev": true
+					"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 				}
+			}
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
 			}
 		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-			"dev": true
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"untildify": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.2.tgz",
+			"integrity": "sha1-fx8wIFWz/qDz6B3HjrNnZstl4/E="
 		},
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-			"dev": true
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
+		"uri-js": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"requires": {
+				"punycode": "2.1.0"
+			}
 		},
 		"url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"dev": true,
 			"requires": {
 				"prepend-http": "1.0.4"
 			}
 		},
+		"url-to-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"user-home": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+			"requires": {
+				"os-homedir": "1.0.2"
+			}
+		},
+		"utf8-bytes": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+			"integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-			"dev": true
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "1.0.2",
 				"spdx-expression-parse": "1.0.4"
 			}
 		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "1.3.0"
 			}
 		},
+		"vinyl": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"requires": {
+				"duplexify": "3.5.4",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"first-chunk-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+				},
+				"strip-bom-stream": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+					"requires": {
+						"first-chunk-stream": "1.0.0",
+						"strip-bom": "2.0.0"
+					}
+				},
+				"vinyl": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"vm2": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.5.2.tgz",
+			"integrity": "sha512-imsgTODim0/3fSDA0g4SeYBF9oAuJnYXpILnA6GJ7rglNPLOv1s+CfgE7pqzOHFEKrJsogIxupE5fW2DI65rIg=="
+		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "1.0.3"
 			}
@@ -3735,7 +9318,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "2.0.0"
 			}
@@ -3743,14 +9325,12 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"wide-align": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
 			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2"
 			}
@@ -3759,14 +9339,42 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"dev": true,
 			"optional": true
+		},
+		"winston": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+			"integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
+			"requires": {
+				"async": "1.0.0",
+				"colors": "1.0.3",
+				"cycle": "1.0.3",
+				"eyes": "0.1.8",
+				"isstream": "0.1.2",
+				"stack-trace": "0.0.10"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+				},
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+				}
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -3775,14 +9383,20 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
 		},
 		"write-file-atomic": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"imurmurhash": "0.1.4",
@@ -3793,7 +9407,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "5.0.0",
 				"graceful-fs": "4.1.11",
@@ -3806,8 +9419,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -3815,7 +9427,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
 			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
-			"dev": true,
 			"requires": {
 				"sort-keys": "2.0.0",
 				"write-json-file": "2.3.0"
@@ -3824,32 +9435,153 @@
 		"xmlcreate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
-			"dev": true
+			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8="
+		},
+		"xregexp": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.1.1.tgz",
+			"integrity": "sha512-QJ1gfSUV7kEOLfpKFCjBJRnfPErUzkNKFMso4kDSmGpp3x6ZgkyKf74inxI7PnnQCFYq5TqYJCd7DrgDN8Q05A=="
 		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-			"dev": true
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yargs": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+			"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+			"requires": {
+				"camelcase": "4.1.0",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"read-pkg-up": "2.0.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"requires": {
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"requires": {
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
+							}
+						}
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				}
+			}
 		},
 		"yargs-parser": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			},
@@ -3857,8 +9589,569 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				}
+			}
+		},
+		"yeoman-assert": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-3.1.1.tgz",
+			"integrity": "sha512-bCuLb/j/WzpvrJZCTdJJLFzm7KK8IYQJ3+dF9dYtNs2CUYyezFJDuULiZ2neM4eqjf45GN1KH/MzCTT3i90wUQ=="
+		},
+		"yeoman-environment": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
+			"integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+			"requires": {
+				"chalk": "2.3.2",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"globby": "6.1.0",
+				"grouped-queue": "0.3.3",
+				"inquirer": "3.3.0",
+				"is-scoped": "1.0.0",
+				"lodash": "4.17.5",
+				"log-symbols": "2.2.0",
+				"mem-fs": "1.1.3",
+				"text-table": "0.2.0",
+				"untildify": "3.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				}
+			}
+		},
+		"yeoman-generator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
+			"integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
+			"requires": {
+				"async": "2.6.0",
+				"chalk": "2.3.2",
+				"cli-table": "0.3.1",
+				"cross-spawn": "5.1.0",
+				"dargs": "5.1.0",
+				"dateformat": "3.0.3",
+				"debug": "3.1.0",
+				"detect-conflict": "1.0.1",
+				"error": "7.0.2",
+				"find-up": "2.1.0",
+				"github-username": "4.1.0",
+				"istextorbinary": "2.2.1",
+				"lodash": "4.17.5",
+				"make-dir": "1.1.0",
+				"mem-fs-editor": "3.0.2",
+				"minimist": "1.2.0",
+				"pretty-bytes": "4.0.2",
+				"read-chunk": "2.1.0",
+				"read-pkg-up": "3.0.0",
+				"rimraf": "2.6.2",
+				"run-async": "2.3.0",
+				"shelljs": "0.8.1",
+				"text-table": "0.2.0",
+				"through2": "2.0.3",
+				"yeoman-environment": "2.0.6"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"requires": {
+						"lodash": "4.17.5"
+					}
+				},
+				"dargs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+				},
+				"dateformat": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+					"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
+					}
+				}
+			}
+		},
+		"yeoman-test": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-1.7.0.tgz",
+			"integrity": "sha512-vJeg2gpWfhbq0HvQ7/yqmsQpYmADBfo9kaW+J6uJASkI7ChLBXNLIBQqaXCA65kWtHXOco+nBm0Km/O9YWk25Q==",
+			"requires": {
+				"inquirer": "3.3.0",
+				"lodash": "4.17.5",
+				"mkdirp": "0.5.1",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2",
+				"sinon": "2.4.1",
+				"yeoman-environment": "2.0.6",
+				"yeoman-generator": "1.1.1"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+				},
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+					"requires": {
+						"lodash": "4.17.5"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"requires": {
+						"restore-cursor": "1.0.1"
+					}
+				},
+				"dargs": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
+					"integrity": "sha1-7H6lDHhWTNNsnV7Bj2Yyn63ieCk="
+				},
+				"dateformat": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+				},
+				"external-editor": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+					"integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+					"requires": {
+						"extend": "3.0.1",
+						"spawn-sync": "1.0.15",
+						"tmp": "0.0.29"
+					}
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"requires": {
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
+					}
+				},
+				"gh-got": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+					"integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+					"requires": {
+						"got": "6.7.1",
+						"is-plain-obj": "1.1.0"
+					}
+				},
+				"github-username": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+					"integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+					"requires": {
+						"gh-got": "5.0.0"
+					}
+				},
+				"globby": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+					"integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+					"requires": {
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "6.0.4",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "6.0.4",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+							"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+							"requires": {
+								"inflight": "1.0.6",
+								"inherits": "2.0.3",
+								"minimatch": "3.0.4",
+								"once": "1.4.0",
+								"path-is-absolute": "1.0.1"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+					"requires": {
+						"chalk": "1.1.3"
+					}
+				},
+				"lolex": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+					"integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"mute-stream": {
+					"version": "0.0.6",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+					"integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+				},
+				"path-to-regexp": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+					"requires": {
+						"isarray": "0.0.1"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"requires": {
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
+					}
+				},
+				"rx": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+					"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+				},
+				"shelljs": {
+					"version": "0.7.8",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+					"requires": {
+						"glob": "7.1.2",
+						"interpret": "1.1.0",
+						"rechoir": "0.6.2"
+					}
+				},
+				"sinon": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+					"integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+					"requires": {
+						"diff": "3.2.0",
+						"formatio": "1.2.0",
+						"lolex": "1.6.0",
+						"native-promise-only": "0.8.1",
+						"path-to-regexp": "1.7.0",
+						"samsam": "1.3.0",
+						"text-encoding": "0.6.4",
+						"type-detect": "4.0.8"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+				},
+				"tmp": {
+					"version": "0.0.29",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+					"requires": {
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"type-detect": {
+					"version": "4.0.8",
+					"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+					"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+				},
+				"untildify": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+					"integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+					"requires": {
+						"os-homedir": "1.0.2"
+					}
+				},
+				"yeoman-generator": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-1.1.1.tgz",
+					"integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
+					"requires": {
+						"async": "2.6.0",
+						"chalk": "1.1.3",
+						"class-extend": "0.1.2",
+						"cli-table": "0.3.1",
+						"cross-spawn": "5.1.0",
+						"dargs": "5.1.0",
+						"dateformat": "2.2.0",
+						"debug": "2.6.9",
+						"detect-conflict": "1.0.1",
+						"error": "7.0.2",
+						"find-up": "2.1.0",
+						"github-username": "3.0.0",
+						"glob": "7.1.2",
+						"istextorbinary": "2.2.1",
+						"lodash": "4.17.5",
+						"mem-fs-editor": "3.0.2",
+						"minimist": "1.2.0",
+						"mkdirp": "0.5.1",
+						"path-exists": "3.0.0",
+						"path-is-absolute": "1.0.1",
+						"pretty-bytes": "4.0.2",
+						"read-chunk": "2.1.0",
+						"read-pkg-up": "2.0.0",
+						"rimraf": "2.6.2",
+						"run-async": "2.3.0",
+						"shelljs": "0.7.8",
+						"text-table": "0.2.0",
+						"through2": "2.0.3",
+						"user-home": "2.0.0",
+						"yeoman-environment": "1.6.6"
+					},
+					"dependencies": {
+						"diff": {
+							"version": "2.2.3",
+							"resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+							"integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
+						},
+						"inquirer": {
+							"version": "1.2.3",
+							"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+							"integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+							"requires": {
+								"ansi-escapes": "1.4.0",
+								"chalk": "1.1.3",
+								"cli-cursor": "1.0.2",
+								"cli-width": "2.2.0",
+								"external-editor": "1.1.1",
+								"figures": "1.7.0",
+								"lodash": "4.17.5",
+								"mute-stream": "0.0.6",
+								"pinkie-promise": "2.0.1",
+								"run-async": "2.3.0",
+								"rx": "4.1.0",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"through": "2.3.8"
+							}
+						},
+						"yeoman-environment": {
+							"version": "1.6.6",
+							"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
+							"integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
+							"requires": {
+								"chalk": "1.1.3",
+								"debug": "2.6.9",
+								"diff": "2.2.3",
+								"escape-string-regexp": "1.0.5",
+								"globby": "4.1.0",
+								"grouped-queue": "0.3.3",
+								"inquirer": "1.2.3",
+								"lodash": "4.17.5",
+								"log-symbols": "1.0.2",
+								"mem-fs": "1.1.3",
+								"text-table": "0.2.0",
+								"untildify": "2.1.0"
+							}
+						}
+					}
+				}
+			}
+		},
+		"yosay": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
+			"integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
+			"requires": {
+				"ansi-regex": "2.1.1",
+				"ansi-styles": "3.2.1",
+				"chalk": "1.1.3",
+				"cli-boxes": "1.0.0",
+				"pad-component": "0.0.1",
+				"string-width": "2.1.1",
+				"strip-ansi": "3.0.1",
+				"taketalk": "1.0.0",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "2.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+							"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"requires": {
+								"ansi-regex": "3.0.0"
+							}
+						}
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
     "contract"
   ],
   "author": "accordproject.org",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {}
 }

--- a/packages/cicero-cli/CHANGELOG.md
+++ b/packages/cicero-cli/CHANGELOG.md
@@ -14,17 +14,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-<a name="0.2.47"></a>
-## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
-
-
-### Bug Fixes
-
-* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
-
-
-
-
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-cli/CHANGELOG.md
+++ b/packages/cicero-cli/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const logger = require('cicero-core').logger;
+const logger = require('@accordproject/cicero-core').logger;
 const Commands = require('./lib/commands');
 
 require('yargs')

--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -14,10 +14,10 @@
 
 'use strict';
 
-const logger = require('cicero-core').logger;
-const Template = require('cicero-core').Template;
-const Clause = require('cicero-core').Clause;
-const Engine = require('cicero-engine').Engine;
+const logger = require('@accordproject/cicero-core').logger;
+const Template = require('@accordproject/cicero-core').Template;
+const Clause = require('@accordproject/cicero-core').Clause;
+const Engine = require('@accordproject/cicero-engine').Engine;
 const CodeGen = require('composer-common').CodeGen;
 const FileWriter = CodeGen.FileWriter;
 const fs = require('fs');

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cicero-cli",
+  "name": "@accordproject/cicero-cli",
   "version": "0.2.46",
   "description": "Cicero CLI",
   "engines": {
@@ -26,6 +26,9 @@
     "legal",
     "tech"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "clause.io",
   "license": "Apache-2.0",
   "bugs": {
@@ -44,8 +47,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.46",
-    "cicero-engine": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.46",
+    "@accordproject/cicero-engine": "^0.2.46",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-cli",
-  "version": "0.2.46",
+  "version": "0.2.48",
   "description": "Cicero CLI",
   "engines": {
     "node": ">=8",
@@ -47,8 +47,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "@accordproject/cicero-core": "^0.2.46",
-    "@accordproject/cicero-engine": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.48",
+    "@accordproject/cicero-engine": "^0.2.48",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-core/CHANGELOG.md
+++ b/packages/cicero-core/CHANGELOG.md
@@ -13,18 +13,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-
-<a name="0.2.47"></a>
-## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
-
-
-### Bug Fixes
-
-* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
-
-
-
-
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-core/CHANGELOG.md
+++ b/packages/cicero-core/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-core/lib/tdl.js
+++ b/packages/cicero-core/lib/tdl.js
@@ -1,4 +1,4 @@
-// Generated automatically by nearley, version 2.12.1
+// Generated automatically by nearley, version 2.13.0
 // http://github.com/Hardmath123/nearley
 (function () {
 function id(x) { return x[0]; }

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cicero-core",
+  "name": "@accordproject/cicero-core",
   "version": "0.2.46",
   "description": "Cicero Core - implementation of Accord Protocol Template Specification",
   "engines": {
@@ -28,6 +28,9 @@
     "smart",
     "contract"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "accordproject.org",
   "license": "Apache-2.0",
   "bugs": {

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-core",
-  "version": "0.2.46",
+  "version": "0.2.48",
   "description": "Cicero Core - implementation of Accord Protocol Template Specification",
   "engines": {
     "node": ">=8",

--- a/packages/cicero-engine/CHANGELOG.md
+++ b/packages/cicero-engine/CHANGELOG.md
@@ -12,19 +12,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
 
 
-
-
-<a name="0.2.47"></a>
-## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
-
-
-### Bug Fixes
-
-* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
-
-
-
-
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-engine/CHANGELOG.md
+++ b/packages/cicero-engine/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-engine/lib/engine.js
+++ b/packages/cicero-engine/lib/engine.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const Logger = require('./logger');
-const logger = require('cicero-core').logger;
+const logger = require('@accordproject/cicero-core').logger;
 const ResourceValidator = require('composer-common/lib/serializer/resourcevalidator');
 
 const {

--- a/packages/cicero-engine/lib/logger.js
+++ b/packages/cicero-engine/lib/logger.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const logger = require('cicero-core').logger;
+const logger = require('@accordproject/cicero-core').logger;
 
 /**
  * <p>

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-engine",
-  "version": "0.2.46",
+  "version": "0.2.48",
   "description": "Cicero Engine - Node.js VM based implementation of Accord Protcol Template Specification execution",
   "engines": {
     "node": ">=8",
@@ -47,7 +47,7 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "@accordproject/cicero-core": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.48",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cicero-engine",
+  "name": "@accordproject/cicero-engine",
   "version": "0.2.46",
   "description": "Cicero Engine - Node.js VM based implementation of Accord Protcol Template Specification execution",
   "engines": {
@@ -25,6 +25,9 @@
     "smart",
     "contract"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "clause.io",
   "license": "Apache-2.0",
   "bugs": {
@@ -44,7 +47,7 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.46",
     "composer-common": "0.17.4",
     "config": "^1.24.0",
     "debug": "^2.6.2",

--- a/packages/cicero-engine/test/data/helloworld/test/logic.js
+++ b/packages/cicero-engine/test/data/helloworld/test/logic.js
@@ -14,9 +14,9 @@
 
 'use strict';
 
-const Template = require('cicero-core').Template;
-const Clause = require('cicero-core').Clause;
-const Engine = require('cicero-engine').Engine;
+const Template = require('@accordproject/cicero-core').Template;
+const Clause = require('@accordproject/cicero-core').Clause;
+const Engine = require('@accordproject/cicero-engine').Engine;
 
 const fs = require('fs');
 const path = require('path');

--- a/packages/cicero-engine/test/data/volumediscount/test/logic.js
+++ b/packages/cicero-engine/test/data/volumediscount/test/logic.js
@@ -14,9 +14,9 @@
 
 'use strict';
 
-const Template = require('cicero-core').Template;
-const Clause = require('cicero-core').Clause;
-const Engine = require('cicero-engine').Engine;
+const Template = require('@accordproject/cicero-core').Template;
+const Clause = require('@accordproject/cicero-core').Clause;
+const Engine = require('@accordproject/cicero-engine').Engine;
 
 const fs = require('fs');
 const path = require('path');

--- a/packages/cicero-engine/test/engine.js
+++ b/packages/cicero-engine/test/engine.js
@@ -14,8 +14,8 @@
 
 'use strict';
 
-const Template = require('cicero-core').Template;
-const Clause = require('cicero-core').Clause;
+const Template = require('@accordproject/cicero-core').Template;
+const Clause = require('@accordproject/cicero-core').Clause;
 const Engine = require('../lib/engine');
 
 const chai = require('chai');

--- a/packages/cicero-server/CHANGELOG.md
+++ b/packages/cicero-server/CHANGELOG.md
@@ -14,17 +14,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-<a name="0.2.47"></a>
-## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
-
-
-### Bug Fixes
-
-* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
-
-
-
-
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-server/CHANGELOG.md
+++ b/packages/cicero-server/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+### Bug Fixes
+
+* Changed require references to new accordproject scoped package ([fe1262d](https://github.com/accordproject/cicero/commit/fe1262d))
+
+
+
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/cicero-server/app.js
+++ b/packages/cicero-server/app.js
@@ -18,9 +18,9 @@
 const fs = require('fs');
 const app = require('express')();
 const bodyParser = require('body-parser');
-const Template = require('cicero-core').Template;
-const Clause = require('cicero-core').Clause;
-const Engine = require('cicero-engine').Engine;
+const Template = require('@accordproject/cicero-core').Template;
+const Clause = require('@accordproject/cicero-core').Clause;
+const Engine = require('@accordproject/cicero-engine').Engine;
 
 if(!process.env.CICERO_DIR) {
     throw new Error('You must set the CICERO_DIR environment variable.');

--- a/packages/cicero-server/package.json
+++ b/packages/cicero-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cicero-server",
+  "name": "@accordproject/cicero-server",
   "version": "0.2.46",
   "description": "Cicero Server - wraps the Cicero Engine and exposes it as a RESTful service",
   "engines": {
@@ -29,6 +29,9 @@
     "smart",
     "contract"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "clause.io",
   "license": "Apache-2.0",
   "bugs": {
@@ -48,8 +51,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "cicero-core": "^0.2.46",
-    "cicero-engine": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.46",
+    "@accordproject/cicero-engine": "^0.2.46",
     "express": "^4.16.2"
   },
   "license-check-config": {

--- a/packages/cicero-server/package.json
+++ b/packages/cicero-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/cicero-server",
-  "version": "0.2.46",
+  "version": "0.2.48",
   "description": "Cicero Server - wraps the Cicero Engine and exposes it as a RESTful service",
   "engines": {
     "node": ">=8",
@@ -51,8 +51,8 @@
     "sinon": "^4.0.1"
   },
   "dependencies": {
-    "@accordproject/cicero-core": "^0.2.46",
-    "@accordproject/cicero-engine": "^0.2.46",
+    "@accordproject/cicero-core": "^0.2.48",
+    "@accordproject/cicero-engine": "^0.2.48",
     "express": "^4.16.2"
   },
   "license-check-config": {

--- a/packages/generator-cicero-template/CHANGELOG.md
+++ b/packages/generator-cicero-template/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="0.2.48"></a>
+## [0.2.48](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.48) (2018-04-10)
+
+
+
+
+**Note:** Version bump only for package @accordproject/generator-cicero-template
+
+<a name="0.2.47"></a>
+## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
+
+
+
+
+**Note:** Version bump only for package @accordproject/generator-cicero-template
+
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/generator-cicero-template/CHANGELOG.md
+++ b/packages/generator-cicero-template/CHANGELOG.md
@@ -11,14 +11,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @accordproject/generator-cicero-template
 
-<a name="0.2.47"></a>
-## [0.2.47](https://github.com/accordproject/cicero/compare/v0.2.46...v0.2.47) (2018-04-10)
-
-
-
-
-**Note:** Version bump only for package @accordproject/generator-cicero-template
-
 <a name="0.2.46"></a>
 ## [0.2.46](https://github.com/accordproject/cicero/compare/v0.2.45...v0.2.46) (2018-03-06)
 

--- a/packages/generator-cicero-template/package.json
+++ b/packages/generator-cicero-template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-cicero-template",
+  "name": "@accordproject/generator-cicero-template",
   "version": "0.2.46",
   "description": "Code generator for a Cicero Template",
   "engines": {
@@ -35,6 +35,9 @@
     "accord project",
     "yeoman-generator"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",

--- a/packages/generator-cicero-template/package.json
+++ b/packages/generator-cicero-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/generator-cicero-template",
-  "version": "0.2.46",
+  "version": "0.2.48",
   "description": "Code generator for a Cicero Template",
   "engines": {
     "node": ">=8",


### PR DESCRIPTION
To bring cicero npm packages under the accordproject scope on the npm package registry, as with the new ergo packages, https://www.npmjs.com/package/@accordproject/ergo-compiler. 