### PR TITLE
fix: #49 Update docs to use new @accordproject scoped packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These instructions were tested using:
 * node version 8.6.0
 
 ```
-npm install -g cicero-cli
+npm install -g @accordproject/cicero-cli
 ```
 
 ## Using an existing Template
@@ -142,7 +142,7 @@ Install the template generator:
 
 ```bash
 npm install -g yo
-npm install -g generator-cicero-template
+npm install -g @accordproject/generator-cicero-template
 ```
 
 Run the template generator:
@@ -150,7 +150,7 @@ Run the template generator:
 > If you have forked the `cicero-template-library` cd into that directory first.
 
 ```bash
-yo cicero-template
+yo @accordproject/cicero-template
 ```
 
 Give your generator a name (no spaces) and then supply a namespace for your template model (again, no spaces). The generator will then create the files and directories required for a basic template (based on the helloworld template).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,11 +9,11 @@ You need ``npm`` and ``node`` to use Cicero. You can download both from nodejs.o
 Once you have installed ``npm`` and ``node`` you can install the Cicero command
 line interface using::
 
-   npm install -g cicero-cli
+   npm install -g @accordproject/cicero-cli
 
 To create new templates you will need to install the template generator tool::
 
     npm install -g yo 
-    npm install -g generator-cicero-template
+    npm install -g @accordproject/generator-cicero-template
 
 .. note:: These instructions were tested using git 2.13.6, npm 5.3.0, node 8.6.0.

--- a/docs/tutorial_001.rst
+++ b/docs/tutorial_001.rst
@@ -102,11 +102,11 @@ Now that you have executed an existing template, let's create a new template.
 Install the template generator::
 
     npm install -g yo 
-    npm install -g generator-cicero-template
+    npm install -g yo @accordproject/generator-cicero-template
 
 Run the template generator::
 
-    yo cicero-template
+    yo @accordproject/cicero-template
 
 .. note:: If you have forked the ``cicero-template-library`` cd into that directory first.
 

--- a/packages/generator-cicero-template/README.md
+++ b/packages/generator-cicero-template/README.md
@@ -6,7 +6,7 @@ First, install [Yeoman](http://yeoman.io) and generator-cicero-template using [n
 
 ```bash
 npm install -g yo
-npm install -g generator-cicero-template
+npm install -g @accordproject/generator-cicero-template
 ```
 
 Then generate your new project:


### PR DESCRIPTION
fix: #49 Update docs to use new @accordproject scoped packages

i.e. `npm install -g cicero-cli` becomes `npm install -g @accordproject/cicero-cli`