### PR TITLE
(fix) contract data should be a Composer object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,9 +1204,9 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"composer-common": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.19.5.tgz",
-			"integrity": "sha512-OZrxMrhuPTD17u6Nh3VCnK4FuwC/Vo7AkQ63nA1fht5tnCQnBx3tScKgJvpS0q7r82NoztxMHP/5cDqyxgWPDQ==",
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.19.6.tgz",
+			"integrity": "sha512-na4WvrnpE6Hzz++m+YjlW/G4W2Dp+jK+WmU63Yo6Es/u98dni8CrZq47wFPEgJ9ew/fAEaeUQpyeMANNPfU22w==",
 			"requires": {
 				"acorn": "5.1.2",
 				"axios": "0.17.1",

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -49,7 +49,7 @@
     "@accordproject/cicero-core": "0.3.14",
     "@accordproject/cicero-engine": "0.3.14",
     "@accordproject/ergo-compiler": "0.0.48",
-    "composer-common": "0.19.5",
+    "composer-common": "0.19.6",
     "yargs": "9.0.1"
   },
   "license-check-config": {

--- a/packages/cicero-common/package.json
+++ b/packages/cicero-common/package.json
@@ -42,7 +42,7 @@
     "nyc": "11.7.2"
   },
   "dependencies": {
-    "composer-common": "0.19.5"
+    "composer-common": "0.19.6"
   },
   "license-check-config": {
     "src": [

--- a/packages/cicero-core/lib/templateinstance.js
+++ b/packages/cicero-core/lib/templateinstance.js
@@ -40,12 +40,14 @@ class TemplateInstance {
         }
         this.template = template;
         this.data = null;
+        this.composerData = null;
     }
 
     /**
      * Set the data for the clause
      * @param {object} data  - the data for the clause, must be an instance of the
-     * template model for the clause's template
+     * template model for the clause's template. This should be a plain JS object
+     * and will be deserialized and validated into the Composer object before assignment.
      */
     setData(data) {
         // verify that data is an instance of the template model
@@ -57,19 +59,32 @@ class TemplateInstance {
 
         // downloadExternalDependencies the data using the template model
         logger.debug('Setting clause data: ' + JSON.stringify(data));
-        const resource = this.template.getSerializer().fromJSON(data);
+        const resource = this.getTemplate().getSerializer().fromJSON(data);
         resource.validate();
 
-        // passed validation!
+        // save the data
         this.data = data;
+
+        // save the composer data
+        this.composerData = resource;
     }
 
     /**
-     * Get the data for the clause
+     * Get the data for the clause. This is a plain JS object. To retrieve the Composer
+     * object call getComposerData().
      * @return {object} - the data for the clause, or null if it has not been set
      */
     getData() {
         return this.data;
+    }
+
+    /**
+     * Get the data for the clause. This is a Composer object. To retrieve the
+     * plain JS object suitable for serialization call toJSON() and retrieve the `data` property.
+     * @return {object} - the data for the clause, or null if it has not been set
+     */
+    getDataAsComposerObject() {
+        return this.composerData;
     }
 
     /**
@@ -107,7 +122,7 @@ class TemplateInstance {
         let hash = '';
 
         if (this.data) {
-            const textToHash = JSON.stringify(this.data);
+            const textToHash = JSON.stringify(this.getData());
             const hasher = crypto.createHash('sha256');
             hasher.update(textToHash);
             hash = '-' + hasher.digest('hex');

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@accordproject/cicero-common": "0.3.14",
     "@accordproject/ergo-compiler": "0.0.48",
-    "composer-common": "0.19.5",
+    "composer-common": "0.19.6",
     "debug": "2.6.2",
     "glob": "7.1.2",
     "ietf-language-tag-regex": "0.0.5",

--- a/packages/cicero-core/test/clause.js
+++ b/packages/cicero-core/test/clause.js
@@ -71,6 +71,9 @@ describe('Clause', () => {
             };
             clause.setData(data);
             clause.getData().should.eql(data);
+
+            // check that the composer data is really a Composer object
+            clause.getDataAsComposerObject().getFullyQualifiedType().should.be.equal('io.clause.latedeliveryandpenalty.TemplateModel');
         });
         it('should throw error for bad $class', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');

--- a/packages/cicero-engine/lib/engine.js
+++ b/packages/cicero-engine/lib/engine.js
@@ -153,7 +153,7 @@ class Engine {
         this.compileJsClause(clause);
         script = this.scripts[clause.getIdentifier()];
 
-        const validContract = clause.getData();
+        const validContract = clause.getDataAsComposerObject();
         const factory = template.getFactory();
         const vm = new VM({
             timeout: 1000,

--- a/packages/cicero-engine/lib/logger.js
+++ b/packages/cicero-engine/lib/logger.js
@@ -47,7 +47,8 @@ class Logger {
             keys.forEach(function(key) {
                 let element = obj[key];
                 if(element.getType) {
-                    printable[key] = this.serializer.toJSON(element, {validate: false, permitResourcesForRelationships: true});
+                    // TODO (DCS) call toJSON once that works for concepts
+                    printable[key] = element.getFullyQualifiedType();
                 }
                 else {
                     printable[key] = element;

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@accordproject/cicero-core": "0.3.14",
-    "composer-common": "0.19.5",
+    "composer-common": "0.19.6",
     "moment": "2.20.1",
     "vm2": "3.5.0"
   },


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

Fix for: #108 

Note that Composer cannot yet serialize Concepts to JSON, so the Composer data is stored alongside the plain JS data. Once https://github.com/accordproject/cicero/pull/115 is merged we can only store the data once.