### PR TITLE
Make script manager paths relative to template root. Fixes 185

### DIFF
--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -96,6 +96,7 @@ describe('Template', () => {
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
+            template.getHash().should.equal('5b221557eb1db6b88c9d0662c5f25c0b8eeff085c1e98165c39e00e9683898bf');
             const buffer = await template.toArchive();
             buffer.should.not.be.null;
             const template2 = await Template.fromArchive(buffer);
@@ -106,6 +107,7 @@ describe('Template', () => {
             template2.getScriptManager().getScripts().length.should.equal(template.getScriptManager().getScripts().length);
             template2.getMetadata().getREADME().should.equal(template.getMetadata().getREADME());
             template2.getMetadata().getSamples().should.eql(template.getMetadata().getSamples());
+            template2.getHash().should.equal(template.getHash());
             const buffer2 = await template2.toArchive();
             buffer2.should.not.be.null;
         });
@@ -352,7 +354,7 @@ describe('Template', () => {
     describe('#getHash', () => {
         it('should return a SHA-256 hash', async () => {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
-            template.getHash().should.equal('04fb59a60a81b940a4afc1eeff93d05718114667d44622c78d3b5458598e248e');
+            template.getHash().should.equal('5b221557eb1db6b88c9d0662c5f25c0b8eeff085c1e98165c39e00e9683898bf');
         });
     });
 


### PR DESCRIPTION
This is a breaking change for anyone relying on hashes as unique identifiers of templates.

However, the current implementation doesn't generate hashes reliably because the hash function is affected by the working directory when a template is loaded by `Template.fromDirectory`.

Fixes #185 