### PR TITLE
feat: Remove updateExternalModels from template.fromArchive

### DIFF
--- a/packages/cicero-core/lib/template.js
+++ b/packages/cicero-core/lib/template.js
@@ -619,7 +619,6 @@ class Template {
 
                 logger.debug(method, 'Adding model files to model manager');
                 template.modelManager.addModelFiles(ctoModelFiles, ctoModelFileNames, true); // Adds all cto files to model manager
-                await template.modelManager.updateExternalModels();
                 template.modelManager.validateModelFiles();
 
                 logger.debug(method, 'Added model files to model manager');

--- a/packages/cicero-core/lib/template.js
+++ b/packages/cicero-core/lib/template.js
@@ -752,10 +752,6 @@ class Template {
             if (file.isSystemModelFile()) {
                 return;
             }
-            // ignore Accord Project system models
-            if (file.getNamespace() === 'org.accordproject.common') {
-                return;
-            }
             if (file.fileName === 'UNKNOWN' || file.fileName === null || !file.fileName) {
                 fileName = file.namespace + '.cto';
             } else {

--- a/packages/cicero-core/test/data/multiple-concepts/models/contract.cto
+++ b/packages/cicero-core/test/data/multiple-concepts/models/contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/multiple-concepts/models/money.cto
+++ b/packages/cicero-core/test/data/multiple-concepts/models/money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/multiple-concepts/models/runtime.cto
+++ b/packages/cicero-core/test/data/multiple-concepts/models/runtime.cto
@@ -1,0 +1,66 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.* from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -32,7 +32,7 @@ function waitForEvent(emitter, eventType) {
     });
 }
 
-async function writeZip(template, ){
+async function writeZip(template){
     try {
         fs.mkdirSync('./test/data/archives');
     } catch (err) {


### PR DESCRIPTION
A template archive should contain all of its dependent model files, see: https://github.com/accordproject/cicero/blob/70ceaf0e00a7c6abe45e3b94ae82cdf8e16d8005/packages/cicero-core/lib/template.js#L746

So, therefore, it is unnecessary to call `updateExternalModels` when loading a template from an archive.

This is expected to add a performance improvement by reducing the number of network calls during template loading.