### PR TITLE
(chore) Do not default NODE_ENV variable to development.

### DIFF
--- a/packages/cicero-core/lib/logger.js
+++ b/packages/cicero-core/lib/logger.js
@@ -19,7 +19,7 @@ const { LEVEL, MESSAGE } = require('triple-beam');
 const jsonStringify = require('fast-safe-stringify');
 const jsome = require('jsome');
 const fs = require('fs');
-const env = process.env.NODE_ENV || 'development';
+const env = process.env.NODE_ENV;
 const tsFormat = () => (new Date()).toLocaleTimeString();
 
 /**


### PR DESCRIPTION
This prevents cicero logger from creating a log folder in the file
system

Signed-off-by: Petr Gazarov <petrgazarov@gmail.com>