### PR TITLE
Feature: current time parameter in Cicero engine

### DIFF
--- a/packages/cicero-engine/lib/engine.js
+++ b/packages/cicero-engine/lib/engine.js
@@ -351,7 +351,7 @@ class Engine {
         if (now.isValid()) {
             return now;
         } else {
-            throw new Error(`${currentTime} is not a valid moment in format 'YYYY-MM-DDTHH:mm:ssZ'`);
+            throw new Error(`${currentTime} is not a valid moment with the format 'YYYY-MM-DDTHH:mm:ssZ'`);
         }
     }
 

--- a/packages/cicero-engine/lib/steps.js
+++ b/packages/cicero-engine/lib/steps.js
@@ -29,34 +29,34 @@ const { Before, Given, When, Then } = require('cucumber');
 /**
  * Initializes the contract
  *
- * @param {object} engine the Cicero engine
- * @param {object} clause the clause instance
- * @param {string} currentTime the definition of 'now'
- * @param {object} request state data in JSON
+ * @param {object} engine - the Cicero engine
+ * @param {object} clause - the clause instance
+ * @param {object} request - the request data in JSON
+ * @param {string} currentTime - the definition of 'now'
  * @returns {object} Promise to the response
  */
-async function init(engine,clause,currentTime,request) {
+async function init(engine,clause,request,currentTime) {
     if (!request.timestamp) {
         request.timestamp = currentTime;
     }
-    return engine.init(clause,request);
+    return engine.init(clause,request,currentTime);
 }
 
 /**
  * Sends a request to the contract
  *
- * @param {object} engine the Cicero engine
- * @param {object} clause the clause instance
- * @param {string} currentTime the definition of 'now'
- * @param {object} state state data in JSON
- * @param {object} request state data in JSON
+ * @param {object} engine - the Cicero engine
+ * @param {object} clause - the clause instance
+ * @param {object} request - the request data in JSON
+ * @param {object} state - the state data in JSON
+ * @param {string} currentTime - the definition of 'now'
  * @returns {object} Promise to the response
  */
-async function send(engine,clause,currentTime,state,request) {
+async function send(engine,clause,request,state,currentTime) {
     if (!request.timestamp) {
         request.timestamp = currentTime;
     }
-    return engine.execute(clause,request,state);
+    return engine.execute(clause,request,state,currentTime);
 }
 
 /**
@@ -152,7 +152,7 @@ When('it receives the default request', function () {
 
 Then('the initial state( of the contract) should be', function (expectedState) {
     const state = JSON.parse(expectedState);
-    return init(this.engine,this.clause,this.currentTime,initRequest)
+    return init(this.engine,this.clause,initRequest,this.currentTime)
         .then((actualAnswer) => {
             expect(actualAnswer).to.have.property('state');
             expect(actualAnswer).to.not.have.property('error');
@@ -162,7 +162,7 @@ Then('the initial state( of the contract) should be', function (expectedState) {
 
 Then('the initial state( of the contract) should be the default state', function () {
     const state = defaultState;
-    return init(this.engine,this.clause,this.currentTime,initRequest)
+    return init(this.engine,this.clause,initRequest,this.currentTime)
         .then((actualAnswer) => {
             expect(actualAnswer).to.have.property('state');
             expect(actualAnswer).to.not.have.property('error');
@@ -182,7 +182,7 @@ Then('it should respond with', function (expectedResponse) {
         expect(this.answer).to.not.have.property('error');
         return compare(response,this.answer.response);
     } else {
-        return send(this.engine,this.clause,this.currentTime,this.state,this.request)
+        return send(this.engine,this.clause,this.request,this.state,this.currentTime)
             .then((actualAnswer) => {
                 this.answer = actualAnswer;
                 expect(actualAnswer).to.have.property('response');
@@ -199,7 +199,7 @@ Then('the new state( of the contract) should be', function (expectedState) {
         expect(this.answer).to.not.have.property('error');
         return compare(state,this.answer.state);
     } else {
-        return send(this.engine,this.clause,this.currentTime,this.state,this.request)
+        return send(this.engine,this.clause,this.request,this.state,this.currentTime)
             .then((actualAnswer) => {
                 this.answer = actualAnswer;
                 expect(actualAnswer).to.have.property('state');
@@ -216,7 +216,7 @@ Then('the following obligations should have( also) been emitted', function (expe
         expect(this.answer).to.not.have.property('error');
         return compare(emit,this.answer.emit);
     } else {
-        return send(this.engine,this.clause,this.currentTime,this.state,this.request)
+        return send(this.engine,this.clause,this.request,this.state,this.currentTime)
             .then((actualAnswer) => {
                 this.answer = actualAnswer;
                 expect(actualAnswer).to.have.property('emit');
@@ -227,7 +227,7 @@ Then('the following obligations should have( also) been emitted', function (expe
 });
 
 Then('it should reject the request with the error {string}', function (expectedError) {
-    return send(this.engine,this.clause,this.currentTime,this.state,this.request)
+    return send(this.engine,this.clause,this.request,this.state,this.currentTime)
         .catch((actualError) => {
             expect(actualError.message).to.equal(expectedError);
         });

--- a/packages/cicero-engine/lib/steps.js
+++ b/packages/cicero-engine/lib/steps.js
@@ -36,9 +36,6 @@ const { Before, Given, When, Then } = require('cucumber');
  * @returns {object} Promise to the response
  */
 async function init(engine,clause,request,currentTime) {
-    if (!request.timestamp) {
-        request.timestamp = currentTime;
-    }
     return engine.init(clause,request,currentTime);
 }
 
@@ -53,9 +50,6 @@ async function init(engine,clause,request,currentTime) {
  * @returns {object} Promise to the response
  */
 async function send(engine,clause,request,state,currentTime) {
-    if (!request.timestamp) {
-        request.timestamp = currentTime;
-    }
     return engine.execute(clause,request,state,currentTime);
 }
 

--- a/packages/cicero-engine/test/engine.js
+++ b/packages/cicero-engine/test/engine.js
@@ -53,14 +53,13 @@ describe('EngineLatePenalty', () => {
             const request = {};
             request.$class = 'io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest';
             request.forceMajeure = false;
-            request.agreedDelivery = '2017-10-07T16:38:01.412Z';
+            request.agreedDelivery = '2017-10-07T16:38:01Z';
             request.goodsValue = 200.00;
             request.transactionId = '402c8f50-9e61-433e-a7c1-afe61c06ef00';
-            request.timestamp = '2017-11-12T17:38:01.412Z';
             const state = {};
             state.$class = 'org.accordproject.cicero.contract.AccordContractState';
             state.stateId = '1';
-            const result = await engine.execute(clause, request, state);
+            const result = await engine.execute(clause, request, state, '2017-11-12T17:38:01Z');
             result.should.not.be.null;
             result.response.penalty.should.equal(110);
             result.response.buyerMayTerminate.should.equal(true);
@@ -69,14 +68,13 @@ describe('EngineLatePenalty', () => {
         it('should execute a late delivery and penalty smart clause (with a Period)', async function () {
             const request = {};
             request.$class = 'org.accordproject.simplelatedeliveryandpenalty.SimpleLateDeliveryAndPenaltyRequest';
-            request.agreedDelivery = '2017-10-07T16:38:01.412Z';
+            request.agreedDelivery = '2017-10-07T16:38:01Z';
             request.goodsValue = 200.00;
             request.transactionId = '402c8f50-9e61-433e-a7c1-afe61c06ef00';
-            request.timestamp = '2019-11-12T17:38:01.412Z';
             const state = {};
             state.$class = 'org.accordproject.cicero.contract.AccordContractState';
             state.stateId = '1';
-            const result = await engine.execute(clause2, request, state);
+            const result = await engine.execute(clause2, request, state, '2019-11-12T17:38:01Z');
             result.should.not.be.null;
             result.response.penalty.should.equal(87.5);
             result.response.buyerMayTerminate.should.equal(true);
@@ -281,8 +279,7 @@ describe('EngineHelloEmitInit', () => {
         it('should execute a smart clause which emits during initialization', async function () {
             const request = {
                 '$class': 'org.accordproject.helloemit.MyInitRequest',
-                'input': 'Accord Project',
-                'timestamp': '2017-11-12T17:38:01.412Z'
+                'input': 'Accord Project'
             };
             const result = await engine.init(clause, request);
             result.should.not.be.null;

--- a/packages/cicero-engine/test/features/latedeliveryandpenalty.feature
+++ b/packages/cicero-engine/test/features/latedeliveryandpenalty.feature
@@ -12,15 +12,15 @@ Late Delivery and Penalty. In case of delayed delivery except for Force Majeure 
     Then the initial state of the contract should be the default state
 
   Scenario: The contract should return the penalty amount but not allow the buyer to terminate
-    When it receives the request
+    When the current time is "2019-01-11T16:34:00-05:00"
+    And it receives the request
 """
 {
     "$class": "io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest",
     "forceMajeure": false,
     "agreedDelivery": "2018-12-31 03:24:00Z",
     "deliveredAt": null,
-    "goodsValue": 200.00,
-    "timestamp": "2019-01-11T16:34:00-05:00"
+    "goodsValue": 200.00
 }
 """
     Then it should respond with
@@ -34,7 +34,7 @@ Late Delivery and Penalty. In case of delayed delivery except for Force Majeure 
 
   Scenario: The contract should return the penalty amount and allow the buyer to terminate
     When the current time is "2019-01-11T16:34:00-05:00"
-    When it receives the request
+    And it receives the request
 """
 {
     "$class": "io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest",
@@ -54,15 +54,15 @@ Late Delivery and Penalty. In case of delayed delivery except for Force Majeure 
 """
 
   Scenario: The contract should not allow the late delivery clause to be triggered when the delivery is on time
-    When it receives the request
+    When the current time is "2019-01-11T16:34:00-05:00"
+    And it receives the request
 """
 {
     "$class": "io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest",
     "forceMajeure": false,
     "agreedDelivery": "2019-01-31 03:24:00Z",
     "deliveredAt": null,
-    "goodsValue": 200.00,
-    "timestamp": "2019-01-11T16:34:00-05:00"
+    "goodsValue": 200.00
 }
 """
     Then it should reject the request with the error "Cannot exercise late delivery before delivery date"


### PR DESCRIPTION
Implementation note: The currentTime creation expects a strict ISO 8601 syntax with an explicit date, time, and time zone, but no milliseconds. This could be made more flexible, but it seems useful to enforce the presence of a timezone.