### PR TITLE
feat(core): support for getKeywords method from package json

### DIFF
--- a/packages/cicero-core/src/metadata.js
+++ b/packages/cicero-core/src/metadata.js
@@ -84,6 +84,14 @@ class Metadata {
             throw new Error('README must be a string');
         }
 
+        if(!packageJson.keywords) {
+            packageJson.keywords = [];
+        }
+
+        if(packageJson.keywords && !Array.isArray(packageJson.keywords)) {
+            throw new Error('keywords property in package.json must be an array.');
+        }
+
         this.readme = readme;
         this.samples = samples;
         this.request = request;
@@ -248,6 +256,18 @@ class Metadata {
      */
     getName() {
         return this.packageJson.name;
+    }
+
+    /**
+     * Returns the name for this template.
+     * @return {Array} the name of the template
+     */
+    getKeywords() {
+        if (this.packageJson.keywords.length < 1 || this.packageJson.keywords === undefined) {
+            return [];
+        } else {
+            return this.packageJson.keywords;
+        }
     }
 
     /**

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -101,6 +101,18 @@ describe('Metadata', () => {
             }, {}, {})).should.throw('README must be a string');
         });
 
+        it('should throw an error if keywords is not an array', () => {
+            return (() => new Metadata({
+                name: 'template',
+                cicero: {
+                    template: 'contract',
+                    language:'ergo',
+                    version:'0.10.2'
+                },
+                keywords: {},
+            }, null, {})).should.throw('keywords property in package.json must be an array.');
+        });
+
         it('should throw an error if template isn\'t contract or clause', () => {
             return (() => new Metadata({
                 name: 'template',

--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -136,11 +136,12 @@ describe('Template', () => {
             template.getScriptManager().getLogic().length.should.equal(1);
             template.getMetadata().getREADME().should.not.be.null;
             template.getMetadata().getRequest().should.not.be.null;
+            template.getMetadata().getKeywords().should.not.be.null;
             template.getName().should.equal('latedeliveryandpenalty');
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
-            template.getHash().should.equal('8336919a11aac0a2a625c8b03670830c22afcc9ae959c97d2328fb8ce6be1c5e');
+            template.getHash().should.equal('e09b822aef69d0db7666febf6bedc750cd43153890391a4ebc0b481168ea352a');
             const buffer = await template.toArchive('ergo');
             buffer.should.not.be.null;
             const template2 = await Template.fromArchive(buffer);
@@ -150,6 +151,7 @@ describe('Template', () => {
             template2.getTemplatizedGrammar().should.equal(template.getTemplatizedGrammar());
             template2.getScriptManager().getScripts().length.should.equal(template.getScriptManager().getScripts().length);
             template2.getMetadata().getREADME().should.equal(template.getMetadata().getREADME());
+            template2.getMetadata().getKeywords().should.eql(template.getMetadata().getKeywords());
             template2.getMetadata().getSamples().should.eql(template.getMetadata().getSamples());
             template2.getHash().should.equal(template.getHash());
             const buffer2 = await template2.toArchive('ergo');
@@ -164,11 +166,12 @@ describe('Template', () => {
             template.getScriptManager().getScripts().length.should.equal(1);
             template.getMetadata().getREADME().should.not.be.null;
             template.getMetadata().getRequest().should.not.be.null;
+            template.getMetadata().getKeywords().should.not.be.null;
             template.getName().should.equal('latedeliveryandpenalty');
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
-            template.getHash().should.equal('ea38feafc4bf75017b3993235bcdeda1fab0f5e5025719e82bad3e34ee9d0064');
+            template.getHash().should.equal('205663283d35d1a8134a60ea5731af77d3c19976d70efa629c03ae1d00d7db6a');
             const buffer = await template.toArchive('javascript');
             buffer.should.not.be.null;
             const template2 = await Template.fromArchive(buffer);
@@ -178,6 +181,7 @@ describe('Template', () => {
             template2.getGrammar().should.equal(template.getGrammar());
             template2.getScriptManager().getScripts().length.should.equal(template.getScriptManager().getScripts().length);
             template2.getMetadata().getREADME().should.equal(template.getMetadata().getREADME());
+            template2.getMetadata().getKeywords().should.eql(template.getMetadata().getKeywords());
             template2.getMetadata().getSamples().should.eql(template.getMetadata().getSamples());
             template2.getHash().should.equal(template.getHash());
             const buffer2 = await template2.toArchive('javascript');
@@ -194,11 +198,12 @@ describe('Template', () => {
             template.getScriptManager().getLogic().length.should.equal(1);
             template.getMetadata().getREADME().should.not.be.null;
             template.getMetadata().getRequest().should.not.be.null;
+            template.getMetadata().getKeywords().should.not.be.null;
             template.getName().should.equal('latedeliveryandpenalty');
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
-            template.getHash().should.equal('8336919a11aac0a2a625c8b03670830c22afcc9ae959c97d2328fb8ce6be1c5e');
+            template.getHash().should.equal('e09b822aef69d0db7666febf6bedc750cd43153890391a4ebc0b481168ea352a');
             template.setArchiveOmitsLogic();
             const buffer = await template.toArchive('ergo');
             buffer.should.not.be.null;
@@ -210,8 +215,9 @@ describe('Template', () => {
             template2.getTemplatizedGrammar().should.equal(template.getTemplatizedGrammar());
             template2.getScriptManager().getScripts().length.should.equal(0);
             template2.getMetadata().getREADME().should.equal(template.getMetadata().getREADME());
+            template2.getMetadata().getKeywords().should.eql(template.getMetadata().getKeywords());
             template2.getMetadata().getSamples().should.eql(template.getMetadata().getSamples());
-            template2.getHash().should.equal('cc3ccd0e086a9c049f06c2e5592eb8061b72e99609961c31896b8e62643679c1');
+            template2.getHash().should.equal('a2493a1e26f817357918e5fa7c8535573d023309048a273476dafc0f9d73b783');
             const buffer2 = await template2.toArchive('ergo');
             buffer2.should.not.be.null;
         });
@@ -504,7 +510,7 @@ describe('Template', () => {
     describe('#getHash', () => {
         it('should return a SHA-256 hash', async () => {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
-            template.getHash().should.equal('8336919a11aac0a2a625c8b03670830c22afcc9ae959c97d2328fb8ce6be1c5e');
+            template.getHash().should.equal('e09b822aef69d0db7666febf6bedc750cd43153890391a4ebc0b481168ea352a');
         });
     });
 
@@ -531,6 +537,32 @@ describe('Template', () => {
             packageJson.name = 'new_name';
             template.setPackageJson(packageJson);
             template.getMetadata().getPackageJson().name.should.be.equal('new_name');
+        });
+    });
+
+    describe('#setKeywords', () => {
+        it('should set the keywords of the metadatas package json', async () => {
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const packageJson = template.getMetadata().getPackageJson();
+            packageJson.keywords = ['payment', 'car', 'automobile'];
+            template.setPackageJson(packageJson);
+            template.getMetadata().getKeywords().should.be.deep.equal(['payment', 'car', 'automobile']);
+        });
+
+        it('should find a specific keyword of the metadatas package json', async () => {
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const packageJson = template.getMetadata().getPackageJson();
+            packageJson.keywords = ['payment', 'car', 'automobile'];
+            template.setPackageJson(packageJson);
+            template.getMetadata().getKeywords()[2].should.be.equal('automobile');
+        });
+
+        it('should return empty array if no keywords exist', async () => {
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const packageJson = template.getMetadata().getPackageJson();
+            packageJson.keywords = [];
+            template.setPackageJson(packageJson);
+            template.getMetadata().getKeywords().should.be.deep.equal([]);
         });
     });
 


### PR DESCRIPTION
No official Issue

Added method to get an array of keywords in the package.json file.
Metadata class will add an empty array if none exists.