### PR TITLE
feat(templateloader): Cache external models

### DIFF
--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -46,7 +46,7 @@ require('yargs')
             argv = Commands.validateParseArgs(argv);
             return Commands.parse(argv.template, argv.sample, argv.out, argv.currentTime)
                 .then((result) => {
-                    Logger.info(JSON.stringify(result));
+                    if(result) {Logger.info(JSON.stringify(result));}
                 })
                 .catch((err) => {
                     Logger.error(err.message);
@@ -78,7 +78,7 @@ require('yargs')
             argv = Commands.validateGenerateTextArgs(argv);
             return Commands.generateText(argv.template, argv.data, argv.out)
                 .then((result) => {
-                    Logger.info(result);
+                    if(result) {Logger.info(JSON.stringify(result));}
                 })
                 .catch((err) => {
                     Logger.error(err.message);
@@ -147,7 +147,7 @@ require('yargs')
             argv = Commands.validateExecuteArgs(argv);
             return Commands.execute(argv.template, argv.sample, argv.request, argv.state, argv.currentTime)
                 .then((result) => {
-                    Logger.info(JSON.stringify(result));
+                    if(result) {Logger.info(JSON.stringify(result));}
                 })
                 .catch((err) => {
                     Logger.error(err.message);
@@ -176,7 +176,7 @@ require('yargs')
             argv = Commands.validateInitArgs(argv);
             return Commands.init(argv.template, argv.sample, argv.currentTime)
                 .then((result) => {
-                    Logger.info(JSON.stringify(result));
+                    if(result) {Logger.info(JSON.stringify(result));}
                 })
                 .catch((err) => {
                     Logger.error(err.message);

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "webpack": "webpack --config webpack.config.js --mode production",
     "build": "babel src -d lib --copy-files && nearleyc ./src/tdl.ne -o ./lib/tdl.js && node scripts/nunjucks-precompile.js",
+    "build:watch": "babel src -d lib --copy-files --watch",
     "prepublishOnly": "npm run build && npm run webpack",
     "prepare": "npm run build",
     "pretest": "npm run lint",

--- a/packages/cicero-core/src/templateloader.js
+++ b/packages/cicero-core/src/templateloader.js
@@ -259,7 +259,6 @@ class TemplateLoader {
      * @return {Promise<Template>} a Promise to the instantiated template
      */
     static async fromDirectory(Template, path, options) {
-
         if (!options) {
             options = {};
         }
@@ -305,6 +304,11 @@ class TemplateLoader {
         template.getModelManager().addModelFiles(modelFiles, modelFileNames, true);
         await template.getModelManager().updateExternalModels();
         Logger.debug(method, 'Added model files', modelFiles.length);
+
+        const externalModelFiles = template.getModelManager().getModels();
+        externalModelFiles.forEach(function (file) {
+            fs.writeFileSync(path + '/models/' + file.name, file.content);
+        });
 
         // load and add the ergo files
         if(template.getMetadata().getErgoVersion()) {


### PR DESCRIPTION
On `template.fromDirectory`, external models are written to disk. 

This behaviour in combination with https://github.com/hyperledger/composer-concerto/pull/36 allows Cicero to be used offline if all external models are locally available instead.

This fixes #361 and #157 