### PR TITLE
Add skipUpdateExternalModels option to Template.fromDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,3 @@ typings/
 
 # User Data
 userdata.json
-
-# Derived CTO files
-@models.accordproject.org*.cto

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "npm run pkgcheck && npm run bootstrap",
     "bootstrap": "lerna bootstrap",
     "pretest": "npm run doc && npm run licchk",
-    "test": "lerna exec -- npm run test",
+    "test": "lerna exec -- npm run test:cov",
     "publish": "./scripts/manualrelease.sh",
     "repoclean": "lerna clean",
     "licchk": "license-check-and-add",

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -21,8 +21,8 @@
     "test:cucumber": "cucumber-js test/features --require .cucumber.js --world-parameters '{\"rootdir\":\"./test\"}'",
     "test:mocha": "mocha",
     "test:all": "npm run test:mocha && npm run test:cucumber",
-    "test:cov": "nyc npm run test:all",
-    "test": "npm run test:all && npm run test:cov"
+    "test:cov": "nyc npm run test",
+    "test": "npm run test:all"
   },
   "repository": {
     "type": "git",

--- a/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-cli/test/data/helloemit/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-cli/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.v2.0.time.cto
+++ b/packages/cicero-cli/test/data/ip-payment/models/@models.accordproject.org.v2.0.time.cto
@@ -1,0 +1,70 @@
+namespace org.accordproject.time
+
+/**
+ * Months of the year
+ */
+enum Month {
+  o January
+  o February
+  o March
+  o April
+  o May
+  o June
+  o July
+  o August
+  o September
+  o October
+  o November
+  o December
+}
+
+/**
+ * Days of the week
+ */
+enum Day {
+  o Monday
+  o Tuesday
+  o Wednesday
+  o Thursday
+  o Friday
+  o Saturday
+  o Sunday
+}
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}
+
+/**
+ * Units for a time period.
+ */
+enum PeriodUnit {
+  o days
+  o weeks
+  o months
+  o quarters
+  o years
+}
+
+/**
+ * A time period. For example, 2 months.
+ */
+concept Period {
+  o Long amount
+  o PeriodUnit unit
+}

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -20,11 +20,13 @@
     "build:watch": "babel src -d lib --copy-files --watch",
     "prepublishOnly": "npm run build && npm run webpack",
     "prepare": "npm run build",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run build",
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check",
-    "test": "npm run build && nyc mocha"
+    "test": "mocha",
+    "test:cov": "nyc npm run test"
+
   },
   "repository": {
     "type": "git",

--- a/packages/cicero-core/src/templateloader.js
+++ b/packages/cicero-core/src/templateloader.js
@@ -262,7 +262,6 @@ class TemplateLoader {
         if (!options) {
             options = {};
         }
-
         const method = 'fromDirectory';
 
         // grab the README.md
@@ -302,13 +301,15 @@ class TemplateLoader {
         });
 
         template.getModelManager().addModelFiles(modelFiles, modelFileNames, true);
-        await template.getModelManager().updateExternalModels();
-        Logger.debug(method, 'Added model files', modelFiles.length);
+        if(!options.skipUpdateExternalModels){
+            await template.getModelManager().updateExternalModels();
+            Logger.debug(method, 'Added model files', modelFiles.length);
 
-        const externalModelFiles = template.getModelManager().getModels();
-        externalModelFiles.forEach(function (file) {
-            fs.writeFileSync(path + '/models/' + file.name, file.content);
-        });
+            const externalModelFiles = template.getModelManager().getModels();
+            externalModelFiles.forEach(function (file) {
+                fs.writeFileSync(path + '/models/' + file.name, file.content);
+            });
+        }
 
         // load and add the ergo files
         if(template.getMetadata().getErgoVersion()) {

--- a/packages/cicero-core/test/clause.js
+++ b/packages/cicero-core/test/clause.js
@@ -25,6 +25,8 @@ chai.should();
 chai.use(require('chai-things'));
 chai.use(require('chai-as-promised'));
 
+const options = { skipUpdateExternalModels: true };
+
 describe('Clause', () => {
 
     const testLatePenaltyInput = fs.readFileSync(path.resolve(__dirname, 'data/latedeliveryandpenalty', 'sample.txt'), 'utf8');
@@ -36,13 +38,13 @@ describe('Clause', () => {
     describe('#constructor', () => {
 
         it('should create a clause for a latedeliveryandpenalty template', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
             clause.should.not.be.null;
         });
 
         it('should create a clause for a conga template', async function() {
-            const template = await Template.fromDirectory('./test/data/conga');
+            const template = await Template.fromDirectory('./test/data/conga', options);
             const clause = new Clause(template);
             clause.should.not.be.null;
         });
@@ -51,7 +53,7 @@ describe('Clause', () => {
     describe('#setData', () => {
 
         it('should be able to set data', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
 
             // check that we can set/get a valid template model
@@ -80,7 +82,7 @@ describe('Clause', () => {
             clause.getDataAsComposerObject().getFullyQualifiedType().should.be.equal('io.clause.latedeliveryandpenalty.TemplateModel');
         });
         it('should throw error for bad $class', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
             const data = {
                 $class: 'bad.class.name'
@@ -92,7 +94,7 @@ describe('Clause', () => {
     describe('#toJSON', () => {
 
         it('should get a JSON representation of a clause', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
             const data = {
                 $class: 'io.clause.latedeliveryandpenalty.TemplateModel',
@@ -123,7 +125,7 @@ describe('Clause', () => {
     describe('#parse', () => {
 
         it('should be able to set the data from latedeliveryandpenalty natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
             clause.parse(testLatePenaltyInput);
             const data = {
@@ -150,7 +152,7 @@ describe('Clause', () => {
         });
 
         it('should be able to set the data from latedeliveryandpenalty natural language text (with a Period)', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period', options);
             const clause = new Clause(template);
             clause.parse(testLatePenaltyPeriodInput);
             const data = {
@@ -183,7 +185,7 @@ describe('Clause', () => {
         });
 
         it('should be able to set the data from conga natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/conga');
+            const template = await Template.fromDirectory('./test/data/conga', options);
             const clause = new Clause(template);
             clause.parse(testCongaInput);
             const data = {
@@ -199,13 +201,13 @@ describe('Clause', () => {
         });
 
         it('should throw an error for empty text', async function() {
-            const template = await Template.fromDirectory('./test/data/conga');
+            const template = await Template.fromDirectory('./test/data/conga', options);
             const clause = new Clause(template);
             (()=> clause.parse('')).should.throw('Parsing clause text returned a null AST. This may mean the text is valid, but not complete.');
         });
 
         it('should be able to set the data for a text-only clause', async function() {
-            const template = await Template.fromDirectory('./test/data/text-only');
+            const template = await Template.fromDirectory('./test/data/text-only', options);
             const clause = new Clause(template);
             clause.parse(testTextOnlyInput);
             const data = {
@@ -231,7 +233,7 @@ describe('Clause', () => {
         });
 
         it('should create a template from a directory no logic', () => {
-            return Template.fromDirectory('./test/data/no-logic').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/no-logic', options).should.be.fulfilled;
         });
 
     });
@@ -239,7 +241,7 @@ describe('Clause', () => {
     describe('#generateText', () => {
 
         it('should be able to roundtrip latedelivery natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const clause = new Clause(template);
             clause.parse(testLatePenaltyInput);
             const nl = clause.generateText();
@@ -247,7 +249,7 @@ describe('Clause', () => {
         });
 
         it('should be able to roundtrip latedelivery natural language text (with a Period)', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period', options);
             const clause = new Clause(template);
             clause.parse(testLatePenaltyPeriodInput);
             const nl = clause.generateText();
@@ -255,7 +257,7 @@ describe('Clause', () => {
         });
 
         it('should be able to roundtrip conga natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/conga');
+            const template = await Template.fromDirectory('./test/data/conga', options);
             const clause = new Clause(template);
             clause.parse(testCongaInput);
             const nl = clause.generateText();
@@ -263,7 +265,7 @@ describe('Clause', () => {
         });
 
         it('should be able to roundtrip alltypes natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/alltypes');
+            const template = await Template.fromDirectory('./test/data/alltypes', options);
             const clause = new Clause(template);
             clause.parse(testAllTypesInput);
             const nl = clause.generateText();

--- a/packages/cicero-core/test/contract.js
+++ b/packages/cicero-core/test/contract.js
@@ -30,7 +30,7 @@ describe('Contract', () => {
 
     describe('#parse', () => {
         it('should be able to set the data from copyright-license natural language text', async function() {
-            const template = await Template.fromDirectory('./test/data/copyright-license');
+            const template = await Template.fromDirectory('./test/data/copyright-license', { skipUpdateExternalModels: true });
             const contract = new Contract(template);
             contract.parse(sampleText);
         });

--- a/packages/cicero-core/test/data/alltypes/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/alltypes/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/bad-copyright-license/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/bad-locale/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-core/test/data/bad-logic/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/bad-property/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/conga/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/conga/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/conga/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/conga/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/conga/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/conga/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/copyright-license/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/formatted-dates-D MMM YYYY HH:mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-D MMM YYYY HH:mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-D MMM YYYY HH:mm:ssZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-D MMM YYYY HH:mm:ssZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-D MMM YYYYZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-D MMM YYYYZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-D MMMM YYYY HH:mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-D MMMM YYYY HH:mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-D-M-YYYY H mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-D-M-YYYY H mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-DD-MMM-YYYY H mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-DD-MMM-YYYY H mm:ss.SSSZ/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-DD_MM_YYYY/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-DD_MM_YYYY/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-MM_DD_YYYY/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-MM_DD_YYYY/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/helloemit/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/hellomodule-bug/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/hellomodule/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.v2.0.time.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.v2.0.time.cto
@@ -1,0 +1,70 @@
+namespace org.accordproject.time
+
+/**
+ * Months of the year
+ */
+enum Month {
+  o January
+  o February
+  o March
+  o April
+  o May
+  o June
+  o July
+  o August
+  o September
+  o October
+  o November
+  o December
+}
+
+/**
+ * Days of the week
+ */
+enum Day {
+  o Monday
+  o Tuesday
+  o Wednesday
+  o Thursday
+  o Friday
+  o Saturday
+  o Sunday
+}
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}
+
+/**
+ * Units for a time period.
+ */
+enum PeriodUnit {
+  o days
+  o weeks
+  o months
+  o quarters
+  o years
+}
+
+/**
+ * A time period. For example, 2 months.
+ */
+concept Period {
+  o Long amount
+  o PeriodUnit unit
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/locales-conga/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/no-concepts/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-core/test/data/no-logic/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/no-sample/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-core/test/data/text-only/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-core/test/data/with-node_modules/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -70,14 +70,14 @@ describe('Metadata', () => {
             (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',cicero:caretRange(ciceroVersion)}
             }, null)).should.throw('sample.txt is required');
         });
         it('should throw an error if samples is not an object', () => {
             (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',cicero:'^0.12.3',ergo:'^0.1.0-0'}
+                accordproject: {template: 'contract',cicero:caretRange(ciceroVersion),ergo:'^0.1.0-0'}
             }, null, 'sample')).should.throw('sample.txt is required');
         });
 
@@ -92,16 +92,16 @@ describe('Metadata', () => {
             (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',cicero:'^0.12.3',ergo:'^0.1.0-0'}
+                accordproject: {template: 'contract',cicero:caretRange(ciceroVersion),ergo:'^0.1.0-0'}
             }, null, {}, 'request')).should.throw('request.json must be an object');
         });
 
         it('should throw an error if package.json does not contain a valid name', () => {
-            (() => new Metadata({version: '1.0.0', accordproject: {template: 'contract',cicero:'^0.12.3',ergo:'^0.1.0-0'}}, null, {})).should.throw('template name can only contain lowercase alphanumerics, _ or -');
+            (() => new Metadata({version: '1.0.0', accordproject: {template: 'contract',cicero:caretRange(ciceroVersion),ergo:'^0.1.0-0'}}, null, {})).should.throw('template name can only contain lowercase alphanumerics, _ or -');
             (() => new Metadata({
                 name: 'template (no 1.)',
                 version: '1.0.0',
-                accordproject: {template: 'contract',cicero:'^0.12.3',ergo:'^0.1.0-0'}
+                accordproject: {template: 'contract',cicero:caretRange(ciceroVersion),ergo:'^0.1.0-0'}
             }, null, {})).should.throw('template name can only contain lowercase alphanumerics, _ or -');
         });
 
@@ -109,7 +109,7 @@ describe('Metadata', () => {
             (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',cicero:'^0.12.3',ergo:'^0.1.0-0'}
+                accordproject: {template: 'contract',cicero:caretRange(ciceroVersion),ergo:'^0.1.0-0'}
             }, {}, {})).should.throw('README must be a string');
         });
 
@@ -120,7 +120,7 @@ describe('Metadata', () => {
                 accordproject: {
                     template: 'contract',
                     ergo:'0.7.3',
-                    cicero:'0.12.3'
+                    cicero:ciceroVersion
                 },
                 keywords: {},
             }, null, {})).should.throw('keywords property in package.json must be an array.');
@@ -130,7 +130,7 @@ describe('Metadata', () => {
             return (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'other',cicero:'0.12.3',ergo:'0.7.3'},
+                accordproject: {template: 'other',cicero:ciceroVersion,ergo:'0.7.3'},
             }, null, {})).should.throw('A cicero template must be either a "contract" or a "clause".');
         });
 
@@ -149,7 +149,7 @@ describe('Metadata', () => {
                 accordproject: {
                     template: 'clause',
                     ergo:'0.7.3',
-                    cicero:'0.12.3',
+                    cicero:ciceroVersion,
                     language: 'ergo'
                 },
             }, null, {})).should.throw('The template version must be a valid semantic version (semver) number.');
@@ -188,7 +188,7 @@ describe('Metadata', () => {
                 name: 'template',
                 description: 'This is a template',
                 version: '0.1.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, '#README', {
                 en: 'sample'
             }, {
@@ -204,7 +204,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, '#README', {
                 en: 'sample'
             }, {
@@ -218,7 +218,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, '#README', {
                 en: 'sample'
             }, {
@@ -230,7 +230,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, '#README', {
                 en: 'sample'
             }, {
@@ -248,7 +248,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {
                 en: 'sample'
             });
@@ -258,7 +258,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             should.not.exist(md.getSample('en'));
             should.not.exist(md.getSample());
@@ -269,7 +269,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {
                 default: 'sample'
             });
@@ -283,7 +283,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.getTemplateType().should.be.equal(0);
         });
@@ -291,7 +291,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.getTemplateType().should.be.equal(0);
         });
@@ -299,7 +299,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'clause',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'clause',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.getTemplateType().should.be.equal(1);
         });
@@ -307,7 +307,7 @@ describe('Metadata', () => {
 
     describe('#satisfiesCiceroVersion', () => {
 
-        it('should satisfy when cicero version is the same as current cicero version', () => {
+        it('should satisfy when cicero version is the same than current cicero version', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
@@ -315,15 +315,15 @@ describe('Metadata', () => {
             }, null, {});
             md.satisfiesCiceroVersion(ciceroVersion).should.be.equal(true);
         });
-        it('should satisfy when cicero version has a lower patch number as cicero version', () => {
+        it('should satisfy when cicero version has a lower patch number than cicero version', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
-            md.satisfiesCiceroVersion(ciceroVersion).should.be.equal(true);
+            md.satisfiesCiceroVersion(incPatch(ciceroVersion)).should.be.equal(true);
         });
-        it('should satisfy when cicero version has a lower patch number as current cicero version (with prerelease tag)', () => {
+        it('should satisfy when cicero version has a lower patch number than current cicero version (with prerelease tag)', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
@@ -332,20 +332,21 @@ describe('Metadata', () => {
             const version = `${incPatch(trimPreRelease(ciceroVersion))}-20190114233635`;
             md.satisfiesCiceroVersion(version).should.be.equal(true);
         });
-        it('should satisfy when cicero version has a lower patch number as cicero version (with prerelease tag)', () => {
+        it('should satisfy when cicero version has a lower patch number than current cicero version (with prerelease tag)', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
-            md.ciceroVersion = '^0.12.3';
-            md.satisfiesCiceroVersion('0.12.4-20190114233635').should.be.equal(true);
+            md.ciceroVersion = caretRange(ciceroVersion);
+            const version = `${incPatch(trimPreRelease(ciceroVersion))}-20190114233635`;
+            md.satisfiesCiceroVersion(version).should.be.equal(true);
         });
-        it('should not satisfy when cicero version has a lower minor number as cicero version', () => {
+        it('should not satisfy when cicero version has a lower minor number than current cicero version', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.ciceroVersion = '^0.11.0';
             md.satisfiesCiceroVersion(ciceroVersion).should.be.equal(false);
@@ -363,28 +364,28 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.ciceroVersion = '^0.11.1';
             md.satisfiesCiceroVersion('0.11.0-20190114233635').should.be.equal(false);
         });
-        it('should not satisfy when cicero version has a higher minor number as cicero version', () => {
+        it('should not satisfy when cicero version has a higher minor number than current cicero version', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
             md.ciceroVersion = '^0.11.0';
             md.satisfiesCiceroVersion(ciceroVersion).should.be.equal(false);
         });
-        it('should not satisfy when cicero version has a higher minor number as cicero version (with prerelease tag)', () => {
+        it('should not satisfy when cicero version has a higher minor number than current cicero version (with prerelease tag)', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {template: 'contract',ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {template: 'contract',ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {});
-            md.ciceroVersion = '^0.12.3';
-            md.satisfiesCiceroVersion('0.12.3-20190114233635').should.be.equal(false);
+            md.ciceroVersion = caretRange(ciceroVersion);
+            md.satisfiesCiceroVersion(`${trimPreRelease(ciceroVersion)}-20190114233635`).should.be.equal(false);
         });
     });
 
@@ -393,7 +394,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, null, {});
             md.getKeywords().should.deep.equal([]);
         });
@@ -402,7 +403,7 @@ describe('Metadata', () => {
                 name: 'template',
                 version: '1.0.0',
                 keywords: null,
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, null, {});
             md.getKeywords().should.deep.equal([]);
         });
@@ -411,7 +412,7 @@ describe('Metadata', () => {
                 name: 'template',
                 version: '1.0.0',
                 keywords: ['foo','bar'],
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, null, {});
             md.getKeywords().should.deep.equal(['foo','bar']);
         });
@@ -422,7 +423,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, null, {
                 en: 'sample'
             });
@@ -435,7 +436,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'cicero'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'cicero'}
             }, null, {
                 en: 'sample'
             });
@@ -445,7 +446,7 @@ describe('Metadata', () => {
             (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3',runtime:'foo'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion),runtime:'foo'}
             }, null, {
                 en: 'sample'
             })).should.throw('Unknown target: foo (available: es5,es6,cicero,java)');
@@ -455,7 +456,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {
                 en: 'sample'
             });
@@ -468,7 +469,7 @@ describe('Metadata', () => {
             const md = new Metadata({
                 name: 'template',
                 version: '1.0.0',
-                accordproject: {ergo:'0.7.3',cicero:'^0.12.3'}
+                accordproject: {ergo:'0.7.3',cicero:caretRange(ciceroVersion)}
             }, null, {
                 en: 'sample'
             });

--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -65,39 +65,45 @@ async function writeZip(template){
 }
 /* eslint-enable */
 
+const options = { skipUpdateExternalModels: true };
+
 describe('Template', () => {
 
     describe('#fromDirectory', () => {
 
         it('should create a template from a directory with no @AccordClauseLogic in logic', () => {
-            return Template.fromDirectory('./test/data/no-logic').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/no-logic', options).should.be.fulfilled;
         });
 
         it('should create a template from a directory with no logic', async () => {
-            const template = await Template.fromDirectory('./test/data/text-only');
+            const template = await Template.fromDirectory('./test/data/text-only', options);
             template.hasLogic().should.equal(false);
         });
 
+        it('should create a template from a directory and download external models by default', async () => {
+            return Template.fromDirectory('./test/data/text-only').should.be.fulfilled;
+        });
+
         it('should create a template from a directory', () => {
-            return Template.fromDirectory('./test/data/latedeliveryandpenalty').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/latedeliveryandpenalty', options).should.be.fulfilled;
         });
 
         it('should throw error when Ergo logic does not parse', async () => {
-            return Template.fromDirectory('./test/data/bad-logic').should.be.rejectedWith('Parse error (at file lib/logic.ergo line 14 col 4). \n    define agreed = request.agreedDelivery;\n    ^^^^^^                                 ');
+            return Template.fromDirectory('./test/data/bad-logic', options).should.be.rejectedWith('Parse error (at file lib/logic.ergo line 14 col 4). \n    define agreed = request.agreedDelivery;\n    ^^^^^^                                 ');
         });
 
         it('should throw an error if archive language is not a valid target', async () => {
-            const templatePromise = Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const templatePromise = Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return templatePromise.then((template) => template.toArchive('foo')).should.be.rejectedWith('Unknown target: foo (available: es5,es6,cicero,java)');
         });
 
         it('should throw an error if archive language is is absent', async () => {
-            const templatePromise = Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const templatePromise = Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return templatePromise.then((template) => template.toArchive()).should.be.rejectedWith('language is required and must be a string');
         });
 
         it('should roundtrip a source template (Ergo)', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.hasLogic().should.equal(true);
             template.getIdentifier().should.equal('latedeliveryandpenalty@0.0.1');
             template.getModelManager().getModelFile('io.clause.latedeliveryandpenalty').should.not.be.null;
@@ -107,7 +113,7 @@ describe('Template', () => {
             template.getMetadata().getREADME().should.not.be.null;
             template.getMetadata().getRequest().should.not.be.null;
             template.getMetadata().getKeywords().should.not.be.null;
-            template.getName().should.equal('latedeliveryandpenalty');
+            template.getName().should.equal('latedeliveryandpenalty', options);
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
@@ -129,7 +135,7 @@ describe('Template', () => {
         });
 
         it('should roundtrip a compiled template (JavaScript)', async function() {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty_js');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty_js', options);
             template.getIdentifier().should.equal('latedeliveryandpenalty@0.0.1');
             template.getModelManager().getModelFile('io.clause.latedeliveryandpenalty').should.not.be.null;
             template.getParserManager().getGrammar().should.not.be.null;
@@ -159,16 +165,16 @@ describe('Template', () => {
         });
 
         it('should throw an error if multiple template models are found', async () => {
-            return Template.fromDirectory('./test/data/multiple-concepts').should.be.rejectedWith('Found multiple instances of org.accordproject.cicero.contract.AccordClause in conga. The model for the template must contain a single asset that extends org.accordproject.cicero.contract.AccordClause.');
+            return Template.fromDirectory('./test/data/multiple-concepts', options).should.be.rejectedWith('Found multiple instances of org.accordproject.cicero.contract.AccordClause in conga. The model for the template must contain a single asset that extends org.accordproject.cicero.contract.AccordClause.');
         });
 
         it('should throw an error if no template models are found', async () => {
-            return Template.fromDirectory('./test/data/no-concepts').should.be.rejectedWith('Failed to find an asset that extends org.accordproject.cicero.contract.AccordClause in conga. The model for the template must contain a single asset that extends org.accordproject.cicero.contract.AccordClause.');
+            return Template.fromDirectory('./test/data/no-concepts', options).should.be.rejectedWith('Failed to find an asset that extends org.accordproject.cicero.contract.AccordClause in conga. The model for the template must contain a single asset that extends org.accordproject.cicero.contract.AccordClause.');
         });
 
         it('should throw an error if a package.json file does not exist', async () => {
             try {
-                await Template.fromDirectory('./test/data/no-packagejson');
+                await Template.fromDirectory('./test/data/no-packagejson', options);
                 assert.isOk(false,'should throw an error if a package.json file does not exist');
             }
             catch(err) {
@@ -177,12 +183,12 @@ describe('Template', () => {
         });
 
         it('should create a template from a directory with a locale sample', () => {
-            return Template.fromDirectory('./test/data/locales-conga').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/locales-conga', options).should.be.fulfilled;
         });
 
         it('should throw an error if a sample.txt file does not exist', async () => {
             try {
-                await Template.fromDirectory('./test/data/no-sample');
+                await Template.fromDirectory('./test/data/no-sample', options);
                 assert.isOk(false,'should throw an error if a sample.txt file does not exist');
             }
             catch(err) {
@@ -192,7 +198,7 @@ describe('Template', () => {
 
         it('should throw an error if the locale is not in the IETF format', async () => {
             try {
-                await Template.fromDirectory('./test/data/bad-locale');
+                await Template.fromDirectory('./test/data/bad-locale', options);
                 assert.isOk(false,'should throw an error if the locale is not in the IETF format');
             }
             catch(err) {
@@ -202,23 +208,23 @@ describe('Template', () => {
 
         // Test case for issue #23
         it('should create template from a directory that has node_modules with duplicate namespace', () => {
-            return Template.fromDirectory('./test/data/with-node_modules').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/with-node_modules', options).should.be.fulfilled;
         });
 
         it('should throw an error for property that is not declared', () => {
-            return Template.fromDirectory('./test/data/bad-property').should.be.rejectedWith('Template references a property \'currency\' that is not declared in the template model');
+            return Template.fromDirectory('./test/data/bad-property', options).should.be.rejectedWith('Template references a property \'currency\' that is not declared in the template model');
         });
 
         it('should throw an error for clause property that is not declared', () => {
-            return Template.fromDirectory('./test/data/bad-copyright-license').should.be.rejectedWith('Template references a property \'badPaymentClause\' that is not declared in the template model');
+            return Template.fromDirectory('./test/data/bad-copyright-license', options).should.be.rejectedWith('Template references a property \'badPaymentClause\' that is not declared in the template model');
         });
 
         it('should create an archive for a template with two Ergo modules', async () => {
-            return Template.fromDirectory('./test/data/hellomodule').should.be.fulfilled;
+            return Template.fromDirectory('./test/data/hellomodule', options).should.be.fulfilled;
         });
 
         it('should fail creating an archive for a template for a wrong Ergo module call', async () => {
-            return Template.fromDirectory('./test/data/hellomodule-bug').should.be.rejectedWith('Type error (at file lib/logic.ergo line 23 col 11). This operator received unexpected arguments');
+            return Template.fromDirectory('./test/data/hellomodule-bug', options).should.be.rejectedWith('Type error (at file lib/logic.ergo line 23 col 11). This operator received unexpected arguments');
         });
     });
 
@@ -299,12 +305,12 @@ describe('Template', () => {
     describe('#setSamples', () => {
 
         it('should not throw for valid samples object', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return (() => template.setSamples({ default: 'sample text' })).should.not.throw();
         });
 
         it('should throw for null samples object', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return (() => template.setSamples(null)).should.throw('sample.txt is required');
         });
     });
@@ -312,7 +318,7 @@ describe('Template', () => {
     describe('#setSample', () => {
 
         it('should not throw for valid sample object', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return (() => template.setSample('sample text','default')).should.not.throw();
         });
     });
@@ -320,7 +326,7 @@ describe('Template', () => {
     describe('#setRequest', () => {
 
         it('should set a new request', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const newrequest = {};
             newrequest.$class = 'io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest';
             newrequest.forceMajeure = true;
@@ -338,7 +344,7 @@ describe('Template', () => {
     describe('#setReadme', () => {
 
         it('should not throw for valid readme text', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return (() => template.setReadme('readme text')).should.not.throw();
         });
     });
@@ -346,7 +352,7 @@ describe('Template', () => {
     describe('#getRequestTypes', () => {
 
         it('should return request types for single accordclauselogic function', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const types = template.getRequestTypes();
             types.should.be.eql([
                 'io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyRequest',
@@ -354,7 +360,7 @@ describe('Template', () => {
         });
 
         it('should return empty array when no logic is defined', async () => {
-            const template = await Template.fromDirectory('./test/data/no-logic');
+            const template = await Template.fromDirectory('./test/data/no-logic', options);
             const types = template.getRequestTypes();
             types.should.be.eql([]);
         });
@@ -363,7 +369,7 @@ describe('Template', () => {
     describe('#getResponseTypes', () => {
 
         it('should return response type for single accordclauselogic function', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const types = template.getResponseTypes();
             types.should.be.eql([
                 'io.clause.latedeliveryandpenalty.LateDeliveryAndPenaltyResponse',
@@ -380,7 +386,7 @@ describe('Template', () => {
     describe('#getEmitTypes', () => {
 
         it('should return the default emit type for a clause without emit type declaration', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const types = template.getEmitTypes();
             types.should.be.eql([
                 'org.accordproject.base.Event',
@@ -388,7 +394,7 @@ describe('Template', () => {
         });
 
         it('should return emit type when declared in a clause', async () => {
-            const template = await Template.fromDirectory('./test/data/helloemit');
+            const template = await Template.fromDirectory('./test/data/helloemit', options);
             const types = template.getEmitTypes();
             types.should.be.eql([
                 'org.accordproject.helloemit.Greeting',
@@ -396,7 +402,7 @@ describe('Template', () => {
         });
 
         it('should return empty array when no logic is defined', async () => {
-            const template = await Template.fromDirectory('./test/data/no-logic');
+            const template = await Template.fromDirectory('./test/data/no-logic', options);
             const types = template.getEmitTypes();
             types.should.be.eql([]);
         });
@@ -405,7 +411,7 @@ describe('Template', () => {
     describe('#getStateTypes', () => {
 
         it('should return the default state type for a clause without state type declaration', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const types = template.getStateTypes();
             types.should.be.eql([
                 'org.accordproject.cicero.contract.AccordContractState',
@@ -413,7 +419,7 @@ describe('Template', () => {
         });
 
         it('should return state type when declared in a clause', async () => {
-            const template = await Template.fromDirectory('./test/data/helloemit');
+            const template = await Template.fromDirectory('./test/data/helloemit', options);
             const types = template.getStateTypes();
             types.should.be.eql([
                 'org.accordproject.cicero.contract.AccordContractState',
@@ -421,7 +427,7 @@ describe('Template', () => {
         });
 
         it('should return empty array when no logic is defined', async () => {
-            const template = await Template.fromDirectory('./test/data/no-logic');
+            const template = await Template.fromDirectory('./test/data/no-logic', options);
             const types = template.getStateTypes();
             types.should.be.eql([]);
         });
@@ -429,7 +435,7 @@ describe('Template', () => {
 
     describe('#getHash', () => {
         it('should return a SHA-256 hash', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.getHash().should.equal('d6d3e3816f4d0deaa659f9b1c7efcb00005da19e6d615c2b7ccf3997a6eab855');
         });
     });
@@ -437,7 +443,7 @@ describe('Template', () => {
     describe('#getTemplateLogic', () => {
         it('should return a Template Logic', async () => {
             const TemplateLogic = require('@accordproject/ergo-compiler').TemplateLogic;
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.getTemplateLogic('cicero').should.be.an.instanceof(TemplateLogic);
         });
     });
@@ -445,7 +451,7 @@ describe('Template', () => {
     describe('#getFactory', () => {
         it('should return a Factory', async () => {
             const Factory = require('@accordproject/ergo-compiler').ComposerConcerto.Factory;
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.getFactory().should.be.an.instanceof(Factory);
         });
     });
@@ -453,14 +459,14 @@ describe('Template', () => {
     describe('#getSerializer', () => {
         it('should return a Serializer', async () => {
             const Serializer = require('@accordproject/ergo-compiler').ComposerConcerto.Serializer;
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.getSerializer().should.be.an.instanceof(Serializer);
         });
     });
 
     describe('#setPackageJson', () => {
         it('should set the package json of the metadata', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const packageJson = template.getMetadata().getPackageJson();
             packageJson.name = 'new_name';
             template.setPackageJson(packageJson);
@@ -470,7 +476,7 @@ describe('Template', () => {
 
     describe('#setKeywords', () => {
         it('should set the keywords of the metadatas package json', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const packageJson = template.getMetadata().getPackageJson();
             packageJson.keywords = ['payment', 'car', 'automobile'];
             template.setPackageJson(packageJson);
@@ -478,7 +484,7 @@ describe('Template', () => {
         });
 
         it('should find a specific keyword of the metadatas package json', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const packageJson = template.getMetadata().getPackageJson();
             packageJson.keywords = ['payment', 'car', 'automobile'];
             template.setPackageJson(packageJson);
@@ -486,7 +492,7 @@ describe('Template', () => {
         });
 
         it('should return empty array if no keywords exist', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             const packageJson = template.getMetadata().getPackageJson();
             packageJson.keywords = [];
             template.setPackageJson(packageJson);
@@ -497,7 +503,7 @@ describe('Template', () => {
     describe('#getLogic', () => {
 
         it('should return all Ergo scripts', async () => {
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             template.getScriptManager().getLogic().length.should.equal(1);
         });
     });
@@ -508,7 +514,7 @@ describe('Template', () => {
             const visitor = {
                 visit: function(thing, parameters){}
             };
-            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
             return (() => template.accept(visitor,{})).should.not.throw();
         });
     });

--- a/packages/cicero-engine/package.json
+++ b/packages/cicero-engine/package.json
@@ -18,7 +18,7 @@
     "test:mocha": "mocha",
     "test:all": "npm run test:mocha",
     "test:cov": "nyc npm run test:all",
-    "test": "npm run test:all && npm run test:cov"
+    "test": "npm run test:all"
   },
   "repository": {
     "type": "git",

--- a/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/helloemit/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/helloemitinit/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/hellomodule/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/helloworld/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.v2.0.time.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty-period/models/@models.accordproject.org.v2.0.time.cto
@@ -1,0 +1,70 @@
+namespace org.accordproject.time
+
+/**
+ * Months of the year
+ */
+enum Month {
+  o January
+  o February
+  o March
+  o April
+  o May
+  o June
+  o July
+  o August
+  o September
+  o October
+  o November
+  o December
+}
+
+/**
+ * Days of the week
+ */
+enum Day {
+  o Monday
+  o Tuesday
+  o Wednesday
+  o Thursday
+  o Friday
+  o Saturday
+  o Sunday
+}
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}
+
+/**
+ * Units for a time period.
+ */
+enum PeriodUnit {
+  o days
+  o weeks
+  o months
+  o quarters
+  o years
+}
+
+/**
+ * A time period. For example, 2 months.
+ */
+concept Period {
+  o Long amount
+  o PeriodUnit unit
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-engine/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-engine/test/data/no-logic/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.usa.business.cto
+++ b/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.usa.business.cto
@@ -1,0 +1,17 @@
+namespace org.accordproject.usa.business
+
+/**
+ * Types of businesses in the USA
+ * Taken from: https://en.wikipedia.org/wiki/List_of_business_entities#United_States
+ */
+enum BusinessEntity {
+  o GENERAL_PARTNERSHIP
+  o LP
+  o LLP
+  o LLLP
+  o LLC
+  o PLLC
+  o CORP
+  o PC
+  o DBA
+}

--- a/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.usa.state.cto
+++ b/packages/cicero-engine/test/data/saft/models/@models.accordproject.org.usa.state.cto
@@ -1,0 +1,57 @@
+namespace org.accordproject.usa.state
+
+/**
+ * States in the USA
+ */
+enum State {
+  o AL
+  o AK
+  o AZ
+  o AR
+  o CA
+  o CO
+  o CT
+  o DE
+  o FL
+  o GA
+  o HI
+  o ID
+  o IL
+  o IN
+  o IA
+  o KS
+  o KY
+  o LA
+  o ME
+  o MD
+  o MA
+  o MI
+  o MN
+  o MS
+  o MO
+  o MT
+  o NE
+  o NV
+  o NH
+  o NJ
+  o NM
+  o NY
+  o NC
+  o ND
+  o OH
+  o OK
+  o OR
+  o PA
+  o RI
+  o SC
+  o SD
+  o TN
+  o TX
+  o UT
+  o VT
+  o VA
+  o WA
+  o WV
+  o WI
+  o WY
+}

--- a/packages/cicero-engine/test/engine.js
+++ b/packages/cicero-engine/test/engine.js
@@ -27,18 +27,25 @@ chai.use(require('chai-as-promised'));
 const fs = require('fs');
 const path = require('path');
 
+const options = { skipUpdateExternalModels: true };
+
 describe('EngineLatePenalty', () => {
 
     let engine;
     let clause;
     let clause2;
+    let template;
+    let template2;
     const testLatePenaltyInput = fs.readFileSync(path.resolve(__dirname, 'data/latedeliveryandpenalty', 'sample.txt'), 'utf8');
     const testLatePenaltyPeriodInput = fs.readFileSync(path.resolve(__dirname, 'data/latedeliveryandpenalty-period', 'sample.txt'), 'utf8');
 
+    before(async () => {
+        template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
+        template2 = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period', options);
+    });
+
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
-        const template2 = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period');
         clause = new Clause(template);
         clause.parse(testLatePenaltyInput);
         clause2 = new Clause(template2);
@@ -119,7 +126,7 @@ describe('EngineLatePenalty (JavaScript)', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty_js');
+        const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty_js', options);
         clause = new Clause(template);
         clause.parse(testLatePenaltyInput);
     });
@@ -183,7 +190,7 @@ describe('EngineHelloWorld', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/helloworld');
+        const template = await Template.fromDirectory('./test/data/helloworld', options);
         clause = new Clause(template);
         clause.parse(helloWorldInput);
     });
@@ -247,7 +254,7 @@ describe('EngineHelloModule', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/hellomodule');
+        const template = await Template.fromDirectory('./test/data/hellomodule', options);
         clause = new Clause(template);
         clause.parse(helloWorldInput);
     });
@@ -278,7 +285,7 @@ describe('EngineHelloEmit', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/helloemit');
+        const template = await Template.fromDirectory('./test/data/helloemit', options);
         clause = new Clause(template);
         clause.parse(helloEmitInput);
     });
@@ -311,7 +318,7 @@ describe('EngineHelloEmitInit', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/helloemitinit');
+        const template = await Template.fromDirectory('./test/data/helloemitinit', options);
         clause = new Clause(template);
         clause.parse(helloEmitInitInput);
     });
@@ -337,7 +344,7 @@ describe('EngineSaft', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/saft');
+        const template = await Template.fromDirectory('./test/data/saft', options);
         clause = new Clause(template);
         clause.parse(saftInput);
     });
@@ -368,7 +375,7 @@ describe('BogusClauses', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/no-logic');
+        const template = await Template.fromDirectory('./test/data/no-logic', options);
         clause = new Clause(template);
         clause.parse(testNoLogic);
     });
@@ -410,7 +417,7 @@ describe('EngineInstallmentSaleErgo', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        const template = await Template.fromDirectory('./test/data/installment-sale-ergo');
+        const template = await Template.fromDirectory('./test/data/installment-sale-ergo', options);
         clause = new Clause(template);
         clause.parse(testLatePenaltyInput);
     });

--- a/packages/cicero-server/package.json
+++ b/packages/cicero-server/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check",
-    "test": "mocha && nyc mocha"
+    "test": "mocha",
+    "test:cov": "nyc npm run test"
   },
   "repository": {
     "type": "git",

--- a/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-server/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-test/package.json
+++ b/packages/cicero-test/package.json
@@ -17,8 +17,8 @@
     "licchk": "license-check",
     "test:cucumber": "cucumber-js test/features --require lib/steps.js --world-parameters '{\"rootdir\":\"./test\"}' && cucumber-js test/data/helloemit/test --require lib/steps.js --world-parameters '{\"rootdir\":\"./test/data/helloemit\"}'",
     "test:all": "npm run test:cucumber",
-    "test:cov": "nyc npm run test:all",
-    "test": "npm run test:all && npm run test:cov"
+    "test:cov": "nyc npm run test",
+    "test": "npm run test:all"
   },
   "repository": {
     "type": "git",

--- a/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-test/test/data/helloemit/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-test/test/data/installment-sale-ergo/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.v2.0.time.cto
+++ b/packages/cicero-test/test/data/ip-payment/models/@models.accordproject.org.v2.0.time.cto
@@ -1,0 +1,70 @@
+namespace org.accordproject.time
+
+/**
+ * Months of the year
+ */
+enum Month {
+  o January
+  o February
+  o March
+  o April
+  o May
+  o June
+  o July
+  o August
+  o September
+  o October
+  o November
+  o December
+}
+
+/**
+ * Days of the week
+ */
+enum Day {
+  o Monday
+  o Tuesday
+  o Wednesday
+  o Thursday
+  o Friday
+  o Saturday
+  o Sunday
+}
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}
+
+/**
+ * Units for a time period.
+ */
+enum PeriodUnit {
+  o days
+  o weeks
+  o months
+  o quarters
+  o years
+}
+
+/**
+ * A time period. For example, 2 months.
+ */
+concept Period {
+  o Long amount
+  o PeriodUnit unit
+}

--- a/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
+++ b/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.cicero.runtime.cto
@@ -1,0 +1,67 @@
+namespace org.accordproject.cicero.runtime
+
+import org.accordproject.cicero.contract.AccordContract from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.cicero.contract.AccordContractState from https://models.accordproject.org/cicero/contract.cto
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+
+/**
+ * Contract API
+ * -- Describes input and output of calls to a contract's clause
+ */
+
+/* A request is a transaction */
+transaction Request {}
+
+/* A response is a transaction */
+transaction Response {}
+
+/* An Error is a transaction */
+abstract transaction ErrorResponse {}
+
+/* An event that represents an obligation that needs to be fulfilled */
+abstract event Obligation {
+  /* A back reference to the governing contract that emitted this obligation */
+  --> AccordContract contract
+
+  /* The party that is obligated */
+  --> Participant promisor optional // TODO make this mandatory once proper party support is in place
+
+  /* The party that receives the performance */
+  --> Participant promisee optional // TODO make this mandatory once proper party support is in place
+
+  /* The time before which the obligation is fulfilled */
+  o DateTime deadline optional
+}
+
+event PaymentObligation extends Obligation{
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}
+
+/* A payload has contract data, a request and a state */
+concept Payload {
+  o AccordContract contract  // the contract data
+  o Request request
+  o AccordContractState state optional
+}
+
+/* If the call to a contract's clause succeeds, it returns a response, a list of events and a new state */
+concept Success {
+  o Response response
+  o AccordContractState state
+  o Event[] emit
+}
+/* If the call to a contract's clause fails, it returns and error */ 
+concept Failure {
+  o ErrorResponse error
+}
+
+/**
+ * The functional signature for a contract call is as follows:
+ * clausecall : String contractName -> String clauseName -> Payload payload -> Success | Failure
+ */

--- a/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
+++ b/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.money.cto
@@ -1,0 +1,221 @@
+namespace org.accordproject.money
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept CryptoMonetaryAmount {
+  o Double doubleValue
+  o CryptoCurrencyCode cryptoCurrencyCode
+}
+
+/**
+ * Cyptocurrency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum CryptoCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}

--- a/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
+++ b/packages/cicero-test/test/data/latedeliveryandpenalty/models/@models.accordproject.org.time.cto
@@ -1,0 +1,23 @@
+/** This model is deprecated, for Cicero 0.10 or later use v2.0/time.cto instead */
+
+namespace org.accordproject.time
+
+/**
+ * Units for a duration.
+ */
+enum TemporalUnit {
+  o seconds
+  o minutes
+  o hours
+  o days
+  o weeks
+  o years
+}
+
+/**
+ * A duration. For example, 6 hours.
+ */
+concept Duration {
+  o Long amount
+  o TemporalUnit unit
+}

--- a/packages/cicero-tools/package.json
+++ b/packages/cicero-tools/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check",
-    "test": "mocha --recursive && nyc mocha --recursive"
+    "test": "mocha --recursive",
+    "test:cov": "nyc npm run test"
   },
   "repository": {
     "type": "git",

--- a/packages/generator-cicero-template/package.json
+++ b/packages/generator-cicero-template/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check",
-    "test": "mocha && nyc mocha"
+    "test": "mocha",
+    "test:cov": "nyc npm run test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds an option to `Template.fromDirectory` to explicitly skip the call to `updateExternalModels`, this allows clients (such as tests) to avoid a network call to download external models if it is known that there is a local cache of the external models.

The option parameter is used like this: 
```
Template.fromDirectory('path', { skipUpdateExternalModels: true });
```
`skipUpdateExternalModels` is `false` by default

This PR also provides a performance improvement to the tests by:
- Using this option during tests
- Commits cached versions of external models to the test templates
- Doesn't run tests twice (because of the lerna source map issue). Instead, it is assumed that locally, developers will run `npm run test` which doesn't apply coverage instrumentation. Each repo also has an `npm run test:cov` script that is used by the CI build that does check coverage. This is assumed safe because the line number issue is likely to be more problematic when running unit tests locally; unit tests should pass locally before CI builds are triggered.

Build time is reduced from ~9 mins to ~4 mins.