### PR TITLE
bug(dateTime) parsing for DateTime without explicit format now consis…

### DIFF
--- a/packages/cicero-core/src/grammars/base.js
+++ b/packages/cicero-core/src/grammars/base.js
@@ -48,9 +48,6 @@ DAY -> DOUBLE_NUMBER
 YEAR -> DOUBLE_NUMBER DOUBLE_NUMBER
 {% (d) => {return '' + d[0] + d[1]}%}
 
-DATE -> MONTH "/" DAY "/" YEAR
-{% (d) => {return '' + d[4] + '-' + d[0] + '-' + d[2]}%}
-
 Word -> [\\S]:*
 {% (d) => {return d[0].join('');}%}
 
@@ -61,7 +58,6 @@ Double -> decimal {% id %}
 Integer -> int {% id %}
 Long -> int {% id %}
 Boolean -> "true" {% id %} | "false" {% id %}
-DateTime -> DATE  {% id %}
 
 # https://github.com/kach/nearley/blob/master/builtin/number.ne
 unsigned_int -> [0-9]:+ {%

--- a/packages/cicero-core/src/parsermanager.js
+++ b/packages/cicero-core/src/parsermanager.js
@@ -293,7 +293,7 @@ class ParserManager {
         if(!action) {
             action = '{% id %}';
 
-            if(element.type === 'FormattedBinding' ) {
+            if(property.getType() === 'DateTime' || element.type === 'FormattedBinding' ) {
                 if(property.getType() !== 'DateTime') {
                     ParserManager._throwTemplateExceptionForElement('Formatted types are currently only supported for DateTime properties.', element);
                 }
@@ -305,13 +305,14 @@ class ParserManager {
                 }
 
                 // push the formatting rule, iff it has not been already declared
-                const formatRule = DateTimeFormatParser.buildDateTimeFormatRule(element.format.value);
+                const format = element.format ? element.format.value : '"MM/DD/YYYY"';
+                const formatRule = DateTimeFormatParser.buildDateTimeFormatRule(format);
                 type = formatRule.name;
                 const ruleExists = parts.modelRules.some(rule => (rule.prefix === formatRule.name));
                 if(!ruleExists) {
                     parts.modelRules.push({
                         prefix: formatRule.name,
-                        symbols: [`${formatRule.tokens} ${formatRule.action} # ${propertyName} as ${element.format.value}`],
+                        symbols: [`${formatRule.tokens} ${formatRule.action} # ${propertyName} as ${format}`],
                     });
                 }
             } else if(element.type === 'ClauseBinding') {

--- a/packages/cicero-core/src/templateinstance.js
+++ b/packages/cicero-core/src/templateinstance.js
@@ -163,18 +163,6 @@ class TemplateInstance {
     }
 
     /**
-     * Left pads a number
-     * @param {*} n - the number
-     * @param {*} width - the number of chars to pad to
-     * @param {string} z - the pad character
-     * @return {string} the left padded string
-     */
-    static pad(n, width, z = '0') {
-        n = n + '';
-        return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
-    }
-
-    /**
      * Recursive function that converts all instances of ParsedDateTime
      * to a Moment.
      * @param {*} obj the input object

--- a/packages/cicero-core/test/clause.js
+++ b/packages/cicero-core/test/clause.js
@@ -277,7 +277,15 @@ describe('Clause', () => {
             const clause = new Clause(template);
             clause.parse(testLatePenaltyInput);
             const nl = clause.generateText();
-            testLatePenaltyInput.should.equal(nl);
+            nl.should.equal(testLatePenaltyInput);
+        });
+
+        it('should be able to generate natural language text with wrapped variables', async function() {
+            const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
+            const clause = new Clause(template);
+            clause.parse(testLatePenaltyInput);
+            const nl = clause.generateText({ wrapVariables: true });
+            nl.should.equal('Late Delivery and Penalty. In case of delayed delivery{{ except for Force Majeure cases,}} the Seller shall pay to the Buyer for every {{9 days}} of delay penalty amounting to {{7}}% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a {{days}} is to be considered a full {{days}}. The total amount of penalty shall not however, exceed {{2}}% of the total value of the Equipment involved in late delivery. If the delay is more than {{2 weeks}}, the Buyer is entitled to terminate this Contract.');
         });
 
         it('should be able to roundtrip latedelivery natural language text (with a Period)', async function() {
@@ -285,7 +293,7 @@ describe('Clause', () => {
             const clause = new Clause(template);
             clause.parse(testLatePenaltyPeriodInput);
             const nl = clause.generateText();
-            testLatePenaltyPeriodInput.should.equal(nl);
+            nl.should.equal(testLatePenaltyPeriodInput);
         });
 
         it('should be able to roundtrip conga natural language text', async function() {
@@ -293,7 +301,7 @@ describe('Clause', () => {
             const clause = new Clause(template);
             clause.parse(testCongaInput);
             const nl = clause.generateText();
-            testCongaInput.should.equal(nl);
+            nl.should.equal(testCongaInput);
         });
 
         it('should be able to roundtrip alltypes natural language text', async function() {

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/README.md
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/README.md
@@ -1,0 +1,4 @@
+
+# Clause Template: Formatted Dates
+
+Test that DateTime can have a custom format applied in a template

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/expected.json
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/expected.json
@@ -1,0 +1,4 @@
+{
+    "$class" : "org.accordproject.test.TemplateModel",
+    "dateTimeProperty" : "2019-12-31T00:00:00.000+00:00"
+}

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/grammar/template.tem
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/grammar/template.tem
@@ -1,0 +1,1 @@
+dateTimeProperty: [{dateTimeProperty}]

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/models/@models.accordproject.org.cicero.contract.cto
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/models/@models.accordproject.org.cicero.contract.cto
@@ -1,0 +1,27 @@
+namespace org.accordproject.cicero.contract
+
+/**
+ * Contract Data
+ * -- Describes the structure of contracts and clauses
+ */
+
+/* A contract state is an asset -- The runtime state of the contract */
+asset AccordContractState identified by stateId {
+  o String stateId
+}
+
+/* A party to a contract */
+participant AccordParty identified by partyId {
+  o String partyId
+}
+
+/* A contract is a asset -- This contains the contract data */
+abstract asset AccordContract identified by contractId {
+  o String contractId
+  --> AccordParty[] parties optional
+}
+
+/* A clause is an asset -- This contains the clause data */
+abstract asset AccordClause identified by clauseId {
+  o String clauseId
+}

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/models/model.cto
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/models/model.cto
@@ -1,0 +1,10 @@
+namespace org.accordproject.test
+
+import org.accordproject.cicero.contract.AccordClause from https://models.accordproject.org/cicero/contract.cto
+
+/**
+ * Defines the data model for the template
+ */
+asset TemplateModel extends AccordClause {
+  o DateTime dateTimeProperty
+}

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/package.json
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "formatted-dates",
+    "version": "0.0.1",
+    "description": "Test formatted dates",
+    "accordproject": {
+      "template": "clause",
+      "ergo": "0.8.0",
+      "cicero": "^0.12.0"
+    }
+  }

--- a/packages/cicero-core/test/data/formatted-dates-NOFORMAT/sample.txt
+++ b/packages/cicero-core/test/data/formatted-dates-NOFORMAT/sample.txt
@@ -1,0 +1,1 @@
+dateTimeProperty: 12/31/2019


### PR DESCRIPTION
…tent with default format

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #375
DateTime variables without format now are parsed exactly as if having the default `YYYY/MM/DD` format.

### Changes
- Remove `DATE` and `DateTime` rules from base parser
- Switch parsing for `DateTime` bindings to use the format `MM/DD/YYYY`
- Add test for `NOFORMAT` formatted dates

