### PR TITLE
fix(generateText) add support for ClauseBinding in generate text (#390)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-	"name": "cicero",
-	"version": "0.13.2",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@accordproject/ergo-compiler": {
 			"version": "0.9.3",
@@ -800,7 +798,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.0.tgz",
 			"integrity": "sha512-bfrqZ0v+Il5TJBsgF2oyepeJg34K2pBItapzP+UT1QMIGpUh/Zc1pQql4jrafamZTqP3ZvdJxaElat8B5K3ICA==",
-			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"aproba": "^2.0.0",
@@ -812,8 +809,7 @@
 				"aproba": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-					"dev": true
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
 				}
 			}
 		},
@@ -821,7 +817,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmpublish/-/libnpmpublish-1.2.0.tgz",
 			"integrity": "sha512-sezhX9FSnPIyrBBvxVocVJVO1uIWPczf6rOmUZSntCWfQMraO8pWTFlDJbroFqPbEqFFHf3eyw8NQ0Eb7OLd1g==",
-			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"aproba": "^2.0.0",
@@ -837,14 +832,12 @@
 				"aproba": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-					"dev": true
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -852,7 +845,6 @@
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/@evocateur/npm-registry-fetch/-/npm-registry-fetch-3.9.1.tgz",
 			"integrity": "sha512-6v1bHbcAypQ+te/1RGSNL4JkK6mcMtcZrUusqo5iKRtYSAig9UJXlOaCcBR+eLywt2DQMNpEwAj24jwWDX5G/w==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.3.4",
 				"bluebird": "^3.5.1",
@@ -867,7 +859,6 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.0.tgz",
 			"integrity": "sha512-nKx8EPxXhzqNfePbqC6603z7Kkf6GBS2q+SNGtBS/bCgS5Q+p3OVR6MXKOkpvC3WHse98W2WLu8QaV9axtfxyw==",
-			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"bluebird": "^3.5.3",
@@ -902,7 +893,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -910,14 +900,12 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -930,7 +918,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.15.0.tgz",
 			"integrity": "sha512-+KrG4GFy/6FISZ+DwWf5Fj5YB4ESa4VTnSn/ujf3VEda6dxngHPN629j+TcPbsdOxUYVah+HuZbC/B8NnkrKpQ==",
-			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.0",
 				"@lerna/bootstrap": "3.15.0",
@@ -947,8 +934,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -956,7 +942,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.14.0.tgz",
 			"integrity": "sha512-RlBkQVNTqk1qvn6PFWiWNiskllUHh6tXbTVm43mZRNd+vhAyvrQC8RWJxH0ECVvnFAt9rSNGRIVbEJ31WnNQLg==",
-			"dev": true,
 			"requires": {
 				"@lerna/package-graph": "3.14.0",
 				"npmlog": "^4.1.2"
@@ -966,7 +951,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.15.0.tgz",
 			"integrity": "sha512-4AxsPKKbgj2Ju03qDddQTpOHvpqnwd0yaiEU/aCcWv/4tDTe79NqUne2Z3+P2WZY0Zzb8+nUKcskwYBMTeq+Mw==",
-			"dev": true,
 			"requires": {
 				"@lerna/batch-packages": "3.14.0",
 				"@lerna/command": "3.15.0",
@@ -997,8 +981,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1006,7 +989,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.15.0.tgz",
 			"integrity": "sha512-Hns1ssI9T9xOTGVc7PT2jUaqzsSkxV3hV/Y7iFO0uKTk+fduyTwGTHU9A/ybQ/xi/9iaJbvaXyjxKiGoEnzmhg==",
-			"dev": true,
 			"requires": {
 				"@lerna/collect-updates": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1019,7 +1001,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz",
 			"integrity": "sha512-7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==",
-			"dev": true,
 			"requires": {
 				"@lerna/collect-uncommitted": "3.14.2",
 				"@lerna/describe-ref": "3.14.2",
@@ -1030,7 +1011,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz",
 			"integrity": "sha512-xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
 				"execa": "^1.0.0",
@@ -1041,7 +1021,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.15.0.tgz",
 			"integrity": "sha512-D1BN7BnJk6YjrSR7E7RiCmWiFVWDo3L+OSe6zDq6rNNYexPBtSi2JOCeF/Dibi3jd2luVu0zkVpUtuEEdPiD+A==",
-			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1057,7 +1036,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
 			"integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
-			"dev": true,
 			"requires": {
 				"@lerna/global-options": "3.13.0",
 				"dedent": "^0.7.0",
@@ -1068,20 +1046,17 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -1091,7 +1066,6 @@
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.2.0",
@@ -1111,7 +1085,6 @@
 					"version": "11.1.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -1123,7 +1096,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz",
 			"integrity": "sha512-4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"chalk": "^2.3.1",
@@ -1135,7 +1107,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.14.2.tgz",
 			"integrity": "sha512-+zSQ2ZovH8Uc0do5dR+sk8VvRJc6Xl+ZnJJGESIl17KSpEw/lVjcOyt6f3BP+WHn+iSOjMWcGvUVA601FIEdZw==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/describe-ref": "3.14.2",
@@ -1147,8 +1118,7 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -1156,7 +1126,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.15.0.tgz",
 			"integrity": "sha512-dZqr4rKFN+veuXakIQ1DcGUpzBgcWKaYFNN4O6/skOdVQaEfGefzo1sZET+q7k/BkypxkhXHXpv5UqqSuL/EHQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/package-graph": "3.14.0",
@@ -1174,7 +1143,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.14.0.tgz",
 			"integrity": "sha512-hGZ2qQZ9uEGf2eeIiIpEodSs9Qkkf/2uYEtNT7QN1RYISPUh6/lKGBssc5dpbCF64aEuxmemWLdlDf1ogG6++w==",
-			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
 				"conventional-changelog-angular": "^5.0.3",
@@ -1191,14 +1159,12 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1206,7 +1172,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.15.0.tgz",
 			"integrity": "sha512-doXGt0HTwTQl8GkC2tOrraA/5OWbz35hJqi7Dsl3Fl0bAxiv9XmF3LykHFJ+YTDHfGpdoJ8tKu66f/VKP16G0w==",
-			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.0",
 				"@lerna/child-process": "3.14.2",
@@ -1231,20 +1196,17 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -1252,7 +1214,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.14.0.tgz",
 			"integrity": "sha512-Kw51HYOOi6UfCKncqkgEU1k/SYueSBXgkNL91FR8HAZH7EPSRTEtp9mnJo568g0+Hog5C+3cOaWySwhHpRG29A==",
-			"dev": true,
 			"requires": {
 				"cmd-shim": "^2.0.2",
 				"fs-extra": "^7.0.0",
@@ -1263,7 +1224,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz",
 			"integrity": "sha512-qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"npmlog": "^4.1.2"
@@ -1273,7 +1233,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.15.0.tgz",
 			"integrity": "sha512-N1Pr0M554Bt+DlVoD+DXWGh92gcq6G9icn8sH5GSqfwi0XCpPNJ2i1BNEZpUQ6ulLWOMa1YHR4PypPxecRGBjA==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1285,7 +1244,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.15.0.tgz",
 			"integrity": "sha512-YuXPd64TNG9wbb3lRvyMARQbdlbMZ1bJZ+GCm0enivnIWUyg0qtBDcfPY2dWpIgOif04zx+K/gmOX4lCaGM4UQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1299,7 +1257,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.14.2.tgz",
 			"integrity": "sha512-Ct8oYvRttbYB9JalngHhirb8o9ZVyLm5a9MpXNevXoHiu6j0vNhI19BQCwNnrL6wZvEHJnzPuUl/jO23tWxemg==",
-			"dev": true,
 			"requires": {
 				"@lerna/collect-updates": "3.14.2",
 				"@lerna/filter-packages": "3.13.0",
@@ -1310,7 +1267,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
 			"integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
 				"multimatch": "^2.1.0",
@@ -1321,7 +1277,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
 			"integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1330,7 +1285,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
 			"integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
-			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
 				"ssri": "^6.0.1",
@@ -1341,7 +1295,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.14.2.tgz",
 			"integrity": "sha512-+2Xh7t4qVmXiXE2utPnh5T7YwSltG74JP7c+EiooRY5+3zjh9MpPOcTKxVY3xKclzpsyXMohk2KpTF4tzA5rrg==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@octokit/plugin-enterprise-rest": "^2.1.1",
@@ -1354,7 +1307,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/gitlab-client/-/gitlab-client-3.15.0.tgz",
 			"integrity": "sha512-OsBvRSejHXUBMgwWQqNoioB8sgzL/Pf1pOUhHKtkiMl6aAWjklaaq5HPMvTIsZPfS6DJ9L5OK2GGZuooP/5c8Q==",
-			"dev": true,
 			"requires": {
 				"node-fetch": "^2.5.0",
 				"npmlog": "^4.1.2",
@@ -1364,14 +1316,12 @@
 		"@lerna/global-options": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
-			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
-			"dev": true
+			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ=="
 		},
 		"@lerna/has-npm-version": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.14.2.tgz",
 			"integrity": "sha512-cG+z5bB8JPd5f+nT2eLN2LmKg06O11AxlnUxgw2W7cLyc7cnsmMSp/rxt2JBMwW2r4Yn+CLLJIRwJZ2Es8jFSw==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"semver": "^5.5.0"
@@ -1380,8 +1330,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1389,7 +1338,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.15.0.tgz",
 			"integrity": "sha512-4GKQgeTXBTwMbZNkYyPdQIVA41HIISD7D6XRNrDaG0falUfvoPsknijQPCBmGqeh66u1Fcn2+4lkL3OCTj2FMg==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1405,7 +1353,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.15.0.tgz",
 			"integrity": "sha512-VOqH6kFbFtfUbXxhSqXKY6bjnVp9nLuLRI6x9tVHOANX2LmSlXm17OUGBnNt+eM4uJLuiUsAR8nTlpCiz//lPQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1418,7 +1365,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.15.0.tgz",
 			"integrity": "sha512-yKHuifADINobvDOLljBGkVGpVwy6J3mg5p9lQXBdOLXBoIKC8o/UKBR9JvZMFvT/Iy6zn6FPy1v5lz9iU1Ib0Q==",
-			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/package-graph": "3.14.0",
@@ -1430,8 +1376,7 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -1439,7 +1384,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.15.0.tgz",
 			"integrity": "sha512-8SvxnlfAnbEzQDf2NL0IxWyUuqWTykF9cHt5/f5TOzgESClpaOkDtqwh/UlE8nVTzWMnxnQUPQi3UTKyJD3i3g==",
-			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1451,7 +1395,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.14.0.tgz",
 			"integrity": "sha512-ZK44Mo8xf/N97eQZ236SPSq0ek6+gk4HqHIx05foEMZVV1iIDH4a/nblLsJNjGQVsIdMYFPaqNJ0z+ZQfiJazQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/query-graph": "3.14.0",
 				"chalk": "^2.3.1",
@@ -1462,7 +1405,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
 			"integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
-			"dev": true,
 			"requires": {
 				"byte-size": "^4.0.3",
 				"columnify": "^1.5.4",
@@ -1474,7 +1416,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
 			"integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
-			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
@@ -1483,8 +1424,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -1492,7 +1432,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.15.0.tgz",
 			"integrity": "sha512-lnbdwc4Ebs7/EI9fTIgbH3dxXnP+SuCcGhG7P5ZjOqo67SY09sRZGcygEzabpvIwXvKpBF8vCd4xxzjnF2u+PA==",
-			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"@lerna/otplease": "3.14.0",
@@ -1505,7 +1444,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.14.2.tgz",
 			"integrity": "sha512-JYJJRtLETrGpcQZa8Rj16vbye399RqnaXmJlZuZ2twjJ2DYVYtwkfsGEOdvdaKw5KVOEpWcAxBA9OMmKQtCLQw==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/get-npm-exec-opts": "3.13.0",
@@ -1520,7 +1458,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.15.0.tgz",
 			"integrity": "sha512-G7rcNcSGjG0La8eHPXDvCvoNXbwNnP6XJ+GPh3CH5xiR/nikfLOa+Bfm4ytdjVWWxnKfCT4qyMTCoV1rROlqQQ==",
-			"dev": true,
 			"requires": {
 				"@evocateur/libnpmpublish": "^1.2.0",
 				"@lerna/otplease": "3.14.0",
@@ -1536,8 +1473,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -1545,7 +1481,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz",
 			"integrity": "sha512-LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/get-npm-exec-opts": "3.13.0",
@@ -1556,7 +1491,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/otplease/-/otplease-3.14.0.tgz",
 			"integrity": "sha512-rYAWzaYZ81bwnrmTkYWGgcc13bl/6DlG7pjWQWNGAJNLzO5zzj0xmXN5sMFJnNvDpSiS/ZS1sIuPvb4xnwLUkg==",
-			"dev": true,
 			"requires": {
 				"@lerna/prompt": "3.13.0",
 				"figgy-pudding": "^3.5.1"
@@ -1566,7 +1500,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
 			"integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1575,7 +1508,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.14.2.tgz",
 			"integrity": "sha512-b3LnJEmIml3sDj94TQT8R+kVyrDlmE7Su0WwcBYZDySXPMSZ38WA2/2Xjy/EWhXlFxp/nUJKyUG78nDrZ/00Uw==",
-			"dev": true,
 			"requires": {
 				"@lerna/get-packed": "3.13.0",
 				"@lerna/package": "3.14.2",
@@ -1591,7 +1523,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.14.2.tgz",
 			"integrity": "sha512-YR/+CzYdufJYfsUlrfuhTjA35iSZpXK7mVOZmeR9iRWhSaqesm4kq2zfxm9vCpZV2oAQQZOwi4eo5h0rQBtdiw==",
-			"dev": true,
 			"requires": {
 				"load-json-file": "^4.0.0",
 				"npm-package-arg": "^6.1.0",
@@ -1602,7 +1533,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.14.0.tgz",
 			"integrity": "sha512-dNpA/64STD5YXhaSlg4gT6Z474WPJVCHoX1ibsVIFu0fVgH609Y69bsdmbvTRdI7r6Dcu4ZfGxdR636RTrH+Eg==",
-			"dev": true,
 			"requires": {
 				"@lerna/prerelease-id-from-version": "3.14.0",
 				"@lerna/validation-error": "3.13.0",
@@ -1614,8 +1544,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1623,7 +1552,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/prerelease-id-from-version/-/prerelease-id-from-version-3.14.0.tgz",
 			"integrity": "sha512-Ap3Z/dNhqQuSrKmK+JmzYvQYI2vowxHvUVxZJiDVilW8dyNnxkCsYFmkuZytk5sxVz4VeGLNPS2RSsU5eeSS+Q==",
-			"dev": true,
 			"requires": {
 				"semver": "^5.5.0"
 			},
@@ -1631,8 +1559,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1640,7 +1567,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.15.0.tgz",
 			"integrity": "sha512-eNGUWiMbQ9kh9kGkomtMnsLypS0rfLqxKgZP2+VnNVtIXjnLv4paeTm+1lkL+naNJUwhnpMk2NSLEeoxT/20QA==",
-			"dev": true,
 			"requires": {
 				"@lerna/package": "3.14.2",
 				"@lerna/validation-error": "3.13.0",
@@ -1659,8 +1585,7 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -1668,7 +1593,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
 			"integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
-			"dev": true,
 			"requires": {
 				"inquirer": "^6.2.0",
 				"npmlog": "^4.1.2"
@@ -1678,7 +1602,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1688,14 +1611,12 @@
 				"chardet": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-					"dev": true
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 				},
 				"external-editor": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
 					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-					"dev": true,
 					"requires": {
 						"chardet": "^0.7.0",
 						"iconv-lite": "^0.4.24",
@@ -1706,7 +1627,6 @@
 					"version": "6.4.1",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
 					"integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
-					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.2.0",
 						"chalk": "^2.4.2",
@@ -1727,7 +1647,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -1737,7 +1656,6 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -1748,7 +1666,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					},
@@ -1756,8 +1673,7 @@
 						"ansi-regex": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 						}
 					}
 				}
@@ -1767,7 +1683,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.15.0.tgz",
 			"integrity": "sha512-6tRRBJ8olLSXfrUsR4f7vSfx0cT1oPi6/v06yI3afDSsUX6eQ3ooZh7gMY4RWmd+nM/IJHTUzhlKF6WhTvo+9g==",
-			"dev": true,
 			"requires": {
 				"@evocateur/libnpmaccess": "^3.1.0",
 				"@evocateur/npm-registry-fetch": "^3.9.1",
@@ -1803,8 +1718,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1812,7 +1726,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
 			"integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1821,7 +1734,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.14.0.tgz",
 			"integrity": "sha512-6YTh3vDMW2hUxHdKeRvx4bosc9lZClKaN+DzC1XKTkwDbWrsjmEzLcemKL6QnyyeuryN2f/eto7P9iSe3z3pQQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/package-graph": "3.14.0",
 				"figgy-pudding": "^3.5.1"
@@ -1831,7 +1743,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
 			"integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
-			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
 				"npmlog": "^4.1.2",
@@ -1842,7 +1753,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz",
 			"integrity": "sha512-eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==",
-			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"npmlog": "^4.1.2",
@@ -1854,7 +1764,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.15.0.tgz",
 			"integrity": "sha512-KQBkzZYoEKmzILKjbjsm1KKVWFBXwAdwzqJWj/lfxxd3V5LRF8STASk8aiw8bSpB0bUL9TU/pbXakRxiNzjDwQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1870,7 +1779,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.14.0.tgz",
 			"integrity": "sha512-GUM3L9MzGRSW0WQ8wbLW1+SYStU1OFjW0GBzShhBnFrO4nGRrU7VchsLpcLu0hk2uCzyhsrDKzifEdOdUyMoEQ==",
-			"dev": true,
 			"requires": {
 				"@lerna/npm-conf": "3.13.0",
 				"figgy-pudding": "^3.5.1",
@@ -1882,7 +1790,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
 			"integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
-			"dev": true,
 			"requires": {
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0"
@@ -1892,7 +1799,6 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.14.0.tgz",
 			"integrity": "sha512-y+KBpC1YExFzGynovt9MY4O/bc3RrJaKeuXieiPfKGKxrdtmZe/r33oj/xePTXZq65jnw3SaU3H8S5CrrdkwDg==",
-			"dev": true,
 			"requires": {
 				"@lerna/query-graph": "3.14.0",
 				"figgy-pudding": "^3.5.1",
@@ -1903,7 +1809,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.14.2.tgz",
 			"integrity": "sha512-tqMwuWi6z1da0AFFbleWyu3H9fqayiV50rjj4anFTfayel9jSjlA1xPG+56sGIP6zUUNuUSc9kLh7oRRmlauoA==",
-			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "3.14.0",
 				"@lerna/package": "3.14.2",
@@ -1915,7 +1820,6 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.14.2.tgz",
 			"integrity": "sha512-Ox7WKXnHZ7IwWlejcCq3n0Hd/yMLv8AwIryhvWxM/RauAge+ML4wg578SsdCyKob8ecgm/R0ytHiU06j81iL1w==",
-			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "3.14.0",
 				"@lerna/resolve-symlink": "3.13.0",
@@ -1929,14 +1833,12 @@
 		"@lerna/timer": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
-			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
-			"dev": true
+			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw=="
 		},
 		"@lerna/validation-error": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
 			"integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1945,7 +1847,6 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.15.0.tgz",
 			"integrity": "sha512-vReYX1NMXZ9PwzTZm97wAl/k3bmRnRZhnQi3mq/m49xTnDavq7p4sbUdFpvu8cVZNKnYS02pNIVGHrQw+K8ZCw==",
-			"dev": true,
 			"requires": {
 				"@lerna/check-working-tree": "3.14.2",
 				"@lerna/child-process": "3.14.2",
@@ -1976,14 +1877,12 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -1991,7 +1890,6 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
 			"integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
-			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2",
 				"write-file-atomic": "^2.3.0"
@@ -2015,7 +1913,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.2.0.tgz",
 			"integrity": "sha512-g4r1MKr8GJ8qubJQp3HP3JrxDY+ZeVqjYBTgtu1lPEDLhfQDY6rOhyZOoHKOw+gaIF6aAcmuvPPNZUro2OwmOg==",
-			"dev": true,
 			"requires": {
 				"deepmerge": "3.3.0",
 				"is-plain-object": "^3.0.0",
@@ -2027,7 +1924,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
 					"requires": {
 						"isobject": "^4.0.0"
 					}
@@ -2035,22 +1931,19 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
 				}
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
-			"integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==",
-			"dev": true
+			"integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw=="
 		},
 		"@octokit/request": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.1.tgz",
 			"integrity": "sha512-LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==",
-			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^5.1.0",
 				"@octokit/request-error": "^1.0.1",
@@ -2065,7 +1958,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
 					"requires": {
 						"isobject": "^4.0.0"
 					}
@@ -2073,8 +1965,7 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
 				}
 			}
 		},
@@ -2082,7 +1973,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
 			"integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
-			"dev": true,
 			"requires": {
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
@@ -2092,7 +1982,6 @@
 			"version": "16.28.2",
 			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.2.tgz",
 			"integrity": "sha512-csuYiHvJ1P/GFDadVn0QhwO83R1+YREjcwCY7ZIezB6aJTRIEidJZj+R7gAkUhT687cqYb4cXTZsDVu9F+Fmug==",
-			"dev": true,
 			"requires": {
 				"@octokit/request": "^4.0.1",
 				"@octokit/request-error": "^1.0.2",
@@ -2313,7 +2202,6 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -2327,8 +2215,7 @@
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-			"dev": true
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -2368,7 +2255,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -2377,7 +2263,6 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
 			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
-			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
 			}
@@ -2407,7 +2292,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true,
 			"optional": true
 		},
 		"ansi-colors": {
@@ -2424,7 +2308,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
 			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-			"dev": true,
 			"requires": {
 				"ansi-wrap": "0.1.0"
 			}
@@ -2445,8 +2328,7 @@
 		"ansi-wrap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-			"dev": true
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
 		},
 		"any-promise": {
 			"version": "1.3.0",
@@ -2575,7 +2457,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -2585,7 +2466,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -2600,7 +2480,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -2638,8 +2517,7 @@
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-			"dev": true
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -2654,8 +2532,7 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-			"dev": true
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -2778,8 +2655,7 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
-			"dev": true
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -3535,14 +3411,12 @@
 		"beeper": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-			"dev": true
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
 		},
 		"before-after-hook": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
-			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
-			"dev": true
+			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -3562,8 +3436,7 @@
 		"bindings": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-			"dev": true
+			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
 		},
 		"bl": {
 			"version": "1.2.2",
@@ -3769,8 +3642,7 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-			"dev": true
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
 		},
 		"buffer": {
 			"version": "5.2.1",
@@ -3823,20 +3695,17 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-			"dev": true
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
-			"dev": true
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"byte-size": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
-			"integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
-			"dev": true
+			"integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw=="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -3915,7 +3784,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
 			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0"
 			},
@@ -3923,8 +3791,7 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-					"dev": true
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
 				}
 			}
 		},
@@ -3955,7 +3822,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
@@ -3965,8 +3831,7 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				}
 			}
 		},
@@ -3978,8 +3843,7 @@
 		"canonical-path": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
-			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ=",
-			"dev": true
+			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3990,7 +3854,6 @@
 			"version": "0.8.10",
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.10.tgz",
 			"integrity": "sha512-l2OUaz/3PU3MZylspVFJvwHCVfWyvcduPq4lv3AzZ2pJzZCo7kNKFNyatwujD7XgvGkNAE/Jhhbh2uARNwNkfw==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
 			}
@@ -4076,8 +3939,7 @@
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-			"dev": true
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -4242,7 +4104,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -4301,8 +4162,7 @@
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
 		},
 		"colornames": {
 			"version": "1.1.1",
@@ -4327,7 +4187,6 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -4336,14 +4195,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4372,7 +4229,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
-			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -4382,7 +4238,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -4550,7 +4405,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.1.tgz",
 			"integrity": "sha512-48+FE5RJ0qc8azwKv4keVQWlni1hZeSjcWr8shBelOBtBHcKj1aJFM9lHRiSc1x7lq416pkvsqfBMhSRja+Lhw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"date-fns": "^1.23.0",
@@ -4567,7 +4421,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -4578,7 +4431,6 @@
 							"version": "5.5.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
 							"requires": {
 								"has-flag": "^3.0.0"
 							}
@@ -4588,20 +4440,17 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				},
 				"read-pkg": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
 					"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
-					"dev": true,
 					"requires": {
 						"normalize-package-data": "^2.3.2",
 						"parse-json": "^4.0.0",
@@ -4611,14 +4460,12 @@
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -4628,7 +4475,6 @@
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
 					},
@@ -4636,8 +4482,7 @@
 						"has-flag": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-							"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-							"dev": true
+							"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 						}
 					}
 				},
@@ -4645,7 +4490,6 @@
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.2.0",
@@ -4665,7 +4509,6 @@
 					"version": "11.1.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -4677,7 +4520,6 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
 			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -4694,8 +4536,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -4716,7 +4557,6 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
 			"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -4726,7 +4566,6 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
 			"integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
-			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^4.0.5",
 				"conventional-commits-parser": "^3.0.2",
@@ -4747,7 +4586,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -4756,7 +4594,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -4766,7 +4603,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -4775,7 +4611,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -4783,14 +4618,12 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4800,7 +4633,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4810,14 +4642,12 @@
 		"conventional-changelog-preset-loader": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
-			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==",
-			"dev": true
+			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA=="
 		},
 		"conventional-changelog-writer": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz",
 			"integrity": "sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==",
-			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^2.0.2",
@@ -4835,7 +4665,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4846,7 +4675,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
 			"integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
-			"dev": true,
 			"requires": {
 				"lodash.ismatch": "^4.4.0",
 				"modify-values": "^1.0.0"
@@ -4856,7 +4684,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
 			"integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
-			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^2.0.0",
@@ -4871,7 +4698,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4882,7 +4708,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz",
 			"integrity": "sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==",
-			"dev": true,
 			"requires": {
 				"concat-stream": "^2.0.0",
 				"conventional-changelog-preset-loader": "^2.1.1",
@@ -4898,7 +4723,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
 					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"inherits": "^2.0.3",
@@ -4978,7 +4802,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
 			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
@@ -4990,7 +4813,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.4.tgz",
 			"integrity": "sha512-eyqUWA/7RT0JagiL0tThVhjbIjoiEUyWCjtUJoOPcWoeofP5WK/jb2OJYoBFrR6DvplR+AxOyuBqk4JHkk5ykA==",
-			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -5177,7 +4999,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -5200,7 +5021,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -5216,8 +5036,7 @@
 		"date-fns": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-			"dev": true
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
 		},
 		"date-now": {
 			"version": "0.1.4",
@@ -5233,7 +5052,6 @@
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
 			"integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
-			"dev": true,
 			"requires": {
 				"bindings": "~1.2.1",
 				"node-addon-api": "^1.6.0"
@@ -5257,8 +5075,7 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-			"dev": true
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
 		},
 		"decache": {
 			"version": "4.4.0",
@@ -5277,7 +5094,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -5286,8 +5102,7 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				}
 			}
 		},
@@ -5307,8 +5122,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -5331,8 +5145,7 @@
 		"deepmerge": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-			"integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
-			"dev": true
+			"integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
 		},
 		"default-require-extensions": {
 			"version": "2.0.0",
@@ -5346,7 +5159,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -5404,8 +5216,7 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -5415,8 +5226,7 @@
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-			"dev": true
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
 		},
 		"des.js": {
 			"version": "1.0.0",
@@ -5445,20 +5255,17 @@
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-			"dev": true
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
 		},
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
 			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-			"dev": true,
 			"requires": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
@@ -5520,7 +5327,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -5528,14 +5334,12 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-			"dev": true
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer2": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~1.1.9"
 			},
@@ -5543,14 +5347,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -5561,8 +5363,7 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -5696,7 +5497,6 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -5722,8 +5522,7 @@
 		"entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-			"dev": true
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"env-variable": {
 			"version": "0.0.5",
@@ -5733,8 +5532,7 @@
 		"err-code": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-			"dev": true
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
 		},
 		"errlop": {
 			"version": "1.1.1",
@@ -5835,14 +5633,12 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-			"dev": true
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -5870,7 +5666,6 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
 			"integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
-			"dev": true,
 			"requires": {
 				"esprima": "^1.2.2",
 				"estraverse": "^1.9.1",
@@ -5882,26 +5677,22 @@
 				"esprima": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-					"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
-					"dev": true
+					"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-					"dev": true
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
 				},
 				"fast-levenshtein": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
-					"dev": true
+					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
 				},
 				"levn": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
 					"integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.0",
 						"type-check": "~0.3.1"
@@ -5911,7 +5702,6 @@
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
 					"integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-					"dev": true,
 					"requires": {
 						"deep-is": "~0.1.2",
 						"fast-levenshtein": "~1.0.0",
@@ -5925,7 +5715,6 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
@@ -5934,8 +5723,7 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
 		},
@@ -6106,7 +5894,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
 			"integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
 				"from": "^0.1.7",
@@ -6120,8 +5907,7 @@
 		"eventemitter3": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-			"dev": true
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
 		},
 		"events": {
 			"version": "3.0.0",
@@ -6195,7 +5981,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -6204,7 +5989,6 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -6216,14 +6000,12 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"is-number": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -6232,7 +6014,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -6241,7 +6022,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6415,7 +6195,6 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
 			"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
-			"dev": true,
 			"requires": {
 				"ansi-gray": "^0.1.1",
 				"color-support": "^1.1.3",
@@ -6465,7 +6244,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
 			"integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
-			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3"
 			}
@@ -6495,14 +6273,12 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
 			"integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-			"dev": true,
 			"requires": {
 				"glob": "5.x",
 				"minimatch": "2.x"
@@ -6512,7 +6288,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -6525,7 +6300,6 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.0.0"
 					}
@@ -6717,7 +6491,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -6725,8 +6498,7 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-			"dev": true
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
 		},
 		"foreground-child": {
 			"version": "1.5.6",
@@ -6797,8 +6569,7 @@
 		"from": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-			"dev": true
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -6842,7 +6613,6 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
 			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -6853,7 +6623,6 @@
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
 			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
-			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -6920,8 +6689,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6939,13 +6707,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6958,18 +6724,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -7072,8 +6835,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -7083,7 +6845,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7096,20 +6857,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -7126,7 +6884,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7199,8 +6956,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -7210,7 +6966,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7286,8 +7041,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -7317,7 +7071,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7335,7 +7088,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7374,13 +7126,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -7398,7 +7148,6 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -7413,14 +7162,12 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7429,7 +7176,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7440,7 +7186,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7450,8 +7195,7 @@
 		"genfun": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
-			"dev": true
+			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -7467,7 +7211,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -7479,14 +7222,12 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-					"dev": true
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -7496,7 +7237,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -7506,7 +7246,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -7515,7 +7254,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -7527,14 +7265,12 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-					"dev": true
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -7552,7 +7288,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -7561,7 +7296,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -7570,7 +7304,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -7580,14 +7313,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7598,7 +7329,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -7608,7 +7338,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -7618,7 +7347,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -7627,7 +7355,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -7635,16 +7362,14 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-					"dev": true
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
 				}
 			}
 		},
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-			"dev": true
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
 		},
 		"get-stdin": {
 			"version": "4.0.1",
@@ -7690,7 +7415,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
 			"integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
-			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -7703,7 +7427,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
-			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -7712,8 +7435,7 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
 		},
@@ -7721,7 +7443,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
 			"integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
-			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -7730,8 +7451,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -7739,7 +7459,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
 			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
-			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"parse-url": "^5.0.0"
@@ -7749,7 +7468,6 @@
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
 			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
-			"dev": true,
 			"requires": {
 				"git-up": "^4.0.0"
 			}
@@ -7758,7 +7476,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
-			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
 			}
@@ -7788,7 +7505,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -7798,7 +7514,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -7806,14 +7521,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7843,7 +7556,6 @@
 			"version": "5.3.5",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
 				"glob": "^5.0.3",
@@ -7859,7 +7571,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -7867,14 +7578,12 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -7885,7 +7594,6 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -7894,7 +7602,6 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7903,7 +7610,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -7915,20 +7621,17 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7936,14 +7639,12 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7952,7 +7653,6 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -7973,7 +7673,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -7982,7 +7681,6 @@
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -7993,14 +7691,12 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -8080,7 +7776,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
 			"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
-			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
@@ -8135,7 +7830,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
 			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
-			"dev": true,
 			"requires": {
 				"event-stream": "^3.3.2",
 				"gulp-util": "^3.0.7",
@@ -8147,7 +7841,6 @@
 					"version": "3.3.5",
 					"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
 					"integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
-					"dev": true,
 					"requires": {
 						"duplexer": "^0.1.1",
 						"from": "^0.1.7",
@@ -8164,7 +7857,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-			"dev": true,
 			"requires": {
 				"convert-source-map": "^1.1.1",
 				"graceful-fs": "^4.1.2",
@@ -8177,7 +7869,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -8186,7 +7877,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -8199,7 +7889,6 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
 			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-uniq": "^1.0.2",
@@ -8224,20 +7913,17 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -8249,14 +7935,12 @@
 				"dateformat": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-					"dev": true
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
 				},
 				"lodash.template": {
 					"version": "3.6.2",
 					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
 					"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-					"dev": true,
 					"requires": {
 						"lodash._basecopy": "^3.0.0",
 						"lodash._basetostring": "^3.0.0",
@@ -8273,7 +7957,6 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
 					"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-					"dev": true,
 					"requires": {
 						"lodash._reinterpolate": "^3.0.0",
 						"lodash.escape": "^3.0.0"
@@ -8282,14 +7965,12 @@
 				"object-assign": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-					"dev": true
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -8297,8 +7978,7 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 				}
 			}
 		},
@@ -8306,7 +7986,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
 			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-			"dev": true,
 			"requires": {
 				"glogg": "^1.0.0"
 			}
@@ -8375,7 +8054,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
 			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
@@ -8401,8 +8079,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8495,8 +8172,7 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
 			"version": "1.6.3",
@@ -8525,7 +8201,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -8535,7 +8210,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -8561,7 +8235,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
 			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-			"dev": true,
 			"requires": {
 				"agent-base": "^4.1.0",
 				"debug": "^3.1.0"
@@ -8571,7 +8244,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -8579,8 +8251,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -8588,7 +8259,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -8635,7 +8305,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
@@ -8649,7 +8318,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
 			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-			"dev": true,
 			"requires": {
 				"caller-path": "^2.0.0",
 				"resolve-from": "^3.0.0"
@@ -8659,7 +8327,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
 					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-					"dev": true,
 					"requires": {
 						"caller-callsite": "^2.0.0"
 					}
@@ -8667,8 +8334,7 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
 				}
 			}
 		},
@@ -8676,7 +8342,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8686,7 +8351,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -8695,7 +8359,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -8705,7 +8368,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -8714,7 +8376,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -8722,14 +8383,12 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"pkg-dir": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.1.0"
 					}
@@ -8769,7 +8428,6 @@
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
 			"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
 				"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -8784,8 +8442,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -8842,8 +8499,7 @@
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -8900,7 +8556,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
 			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-			"dev": true,
 			"requires": {
 				"ci-info": "^1.5.0"
 			}
@@ -8953,20 +8608,17 @@
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-			"dev": true
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -8985,7 +8637,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -9034,8 +8685,7 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -9058,14 +8708,12 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -9102,7 +8750,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
 			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
-			"dev": true,
 			"requires": {
 				"protocols": "^1.1.0"
 			}
@@ -9124,7 +8771,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
 			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-			"dev": true,
 			"requires": {
 				"text-extensions": "^2.0.0"
 			}
@@ -9142,8 +8788,7 @@
 		"is-valid-glob": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-			"dev": true
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -9187,7 +8832,6 @@
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
 			"integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
-			"dev": true,
 			"requires": {
 				"abbrev": "1.0.x",
 				"async": "1.x",
@@ -9208,32 +8852,27 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"esprima": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
-					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
-					"dev": true
+					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw="
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -9244,7 +8883,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-combine/-/istanbul-combine-0.3.0.tgz",
 			"integrity": "sha1-VrLV5joiBZi23ErIrVcucV6ZV3M=",
-			"dev": true,
 			"requires": {
 				"glob": "^5.0.3",
 				"istanbul": "0.3.x",
@@ -9256,7 +8894,6 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -9350,7 +8987,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-merge/-/istanbul-merge-1.1.1.tgz",
 			"integrity": "sha1-db5kNDbU3nI+A6lNHKX1+ZSwvXI=",
-			"dev": true,
 			"requires": {
 				"foreach": "^2.0.5",
 				"glob": "^7.0.5",
@@ -9362,20 +8998,17 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-					"dev": true
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -9386,7 +9019,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -9395,20 +9027,17 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-					"dev": true
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 				},
 				"invert-kv": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9416,14 +9045,12 @@
 				"istanbul-lib-coverage": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
-					"dev": true
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -9432,7 +9059,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -9445,7 +9071,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
 					}
@@ -9454,7 +9079,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -9463,7 +9087,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -9472,7 +9095,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -9482,14 +9104,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -9500,7 +9120,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -9509,14 +9128,12 @@
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9527,7 +9144,6 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9536,7 +9152,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -9544,20 +9159,17 @@
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 				},
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "4.8.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
 						"decamelize": "^1.1.1",
@@ -9579,7 +9191,6 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
-					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
 						"lodash.assign": "^4.0.6"
@@ -9637,7 +9248,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
 			"integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
-			"dev": true,
 			"requires": {
 				"xmlcreate": "^2.0.0"
 			}
@@ -9651,7 +9261,6 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.2.tgz",
 			"integrity": "sha512-S2vzg99C5+gb7FWlrK4TVdyzVPGGkdvpDkCEJH1JABi2PKzPeLu5/zZffcJUifgWUJqXWl41Hoc+MmuM2GukIg==",
-			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.4.4",
 				"bluebird": "^3.5.4",
@@ -9672,14 +9281,12 @@
 				"escape-string-regexp": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-					"dev": true
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
 				},
 				"strip-json-comments": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-					"dev": true
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
 				}
 			}
 		},
@@ -9687,7 +9294,6 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/jsdoc-sphinx/-/jsdoc-sphinx-0.0.6.tgz",
 			"integrity": "sha1-7rerF8QgLEYqBcWwmlb3cQiXvzE=",
-			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"canonical-path": "0.0.2",
@@ -9701,14 +9307,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-					"dev": true
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				}
 			}
 		},
@@ -9933,7 +9537,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -9946,8 +9549,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-			"dev": true
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -10016,7 +9618,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.9"
 			}
@@ -10080,14 +9681,12 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-			"dev": true
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
 		},
 		"lerna": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.15.0.tgz",
 			"integrity": "sha512-kRIQ3bgzkmew5/WZQ0C9WjH0IUf3ZmTNnBwTHfXgLkVY7td0lbwMQFD7zehflUn0zG4ou54o/gn+IfjF0ti/5A==",
-			"dev": true,
 			"requires": {
 				"@lerna/add": "3.15.0",
 				"@lerna/bootstrap": "3.15.0",
@@ -10121,7 +9720,6 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
 			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
-			"dev": true,
 			"requires": {
 				"gulp-license-check": "^1.1.2",
 				"gulp-util": "^3.0.7",
@@ -10133,14 +9731,12 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"escodegen": {
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 					"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-					"dev": true,
 					"requires": {
 						"esprima": "^2.7.1",
 						"estraverse": "^1.9.1",
@@ -10152,20 +9748,17 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-					"dev": true
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
 				},
 				"glob": {
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -10177,14 +9770,12 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
 				},
 				"istanbul": {
 					"version": "0.4.5",
 					"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
 					"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-					"dev": true,
 					"requires": {
 						"abbrev": "1.0.x",
 						"async": "1.x",
@@ -10205,14 +9796,12 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-					"dev": true
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 				},
 				"source-map": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
@@ -10222,7 +9811,6 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -10233,7 +9821,6 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/license-check-and-add/-/license-check-and-add-2.3.6.tgz",
 			"integrity": "sha512-fTSOoJL12YhsTOS+xqutJ7uwIcN4kPcmhCk39FWTjc1Zllyc62JGT1i+NqTfyTh38wzLQDzfLDjqsI4jSzMnfg==",
-			"dev": true,
 			"requires": {
 				"pkg-conf": "^1.1.2"
 			}
@@ -10242,7 +9829,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/licensecheck/-/licensecheck-1.3.0.tgz",
 			"integrity": "sha1-ouuJ7fqZ0ndBZ1LWp9Mp+p+wz9Q=",
-			"dev": true,
 			"requires": {
 				"colors": "1.1.2",
 				"markdown": "0.5.0",
@@ -10254,8 +9840,7 @@
 				"colors": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-					"dev": true
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
 				}
 			}
 		},
@@ -10271,7 +9856,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
 			"integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
-			"dev": true,
 			"requires": {
 				"uc.micro": "^1.0.1"
 			}
@@ -10336,56 +9920,47 @@
 		"lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-			"dev": true
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
 		},
 		"lodash._basetostring": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-			"dev": true
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
 		},
 		"lodash._basevalues": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-			"dev": true
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
 		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-			"dev": true
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 		},
 		"lodash._isiterateecall": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-			"dev": true
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
 		},
 		"lodash._reescape": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-			"dev": true
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
 		},
 		"lodash._reevaluate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-			"dev": true
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-			"dev": true
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
 		},
 		"lodash._root": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-			"dev": true
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -10395,8 +9970,7 @@
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-			"dev": true
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
@@ -10412,7 +9986,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
 			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-			"dev": true,
 			"requires": {
 				"lodash._root": "^3.0.0"
 			}
@@ -10435,26 +10008,22 @@
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-			"dev": true
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-			"dev": true
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-			"dev": true
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
-			"dev": true
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -10465,7 +10034,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true,
 			"requires": {
 				"lodash._getnative": "^3.0.0",
 				"lodash.isarguments": "^3.0.0",
@@ -10480,26 +10048,22 @@
 		"lodash.restparam": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-			"dev": true
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-			"dev": true
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-			"dev": true
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -10509,7 +10073,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -10527,14 +10090,12 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-			"dev": true
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
 		},
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-			"dev": true
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -10588,7 +10149,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -10616,8 +10176,7 @@
 		"macos-release": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
-			"dev": true
+			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
 		},
 		"make-dir": {
 			"version": "2.1.0",
@@ -10639,7 +10198,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.2.tgz",
 			"integrity": "sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==",
-			"dev": true,
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^11.3.3",
@@ -10658,7 +10216,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -10666,8 +10223,7 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -10692,14 +10248,12 @@
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-			"dev": true
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
 		},
 		"map-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-			"dev": true
+			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -10713,7 +10267,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
 			"integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
-			"dev": true,
 			"requires": {
 				"nopt": "~2.1.1"
 			},
@@ -10722,7 +10275,6 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
 					"integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-					"dev": true,
 					"requires": {
 						"abbrev": "1"
 					}
@@ -10733,7 +10285,6 @@
 			"version": "8.4.2",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
 			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"entities": "~1.1.1",
@@ -10745,20 +10296,17 @@
 		"markdown-it-anchor": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
-			"integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
-			"dev": true
+			"integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A=="
 		},
 		"marked": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-			"integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
-			"dev": true
+			"integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
 		},
 		"math-random": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-			"dev": true
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -10773,8 +10321,7 @@
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-			"dev": true
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -10898,7 +10445,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-			"dev": true,
 			"requires": {
 				"camelcase-keys": "^4.0.0",
 				"decamelize-keys": "^1.0.0",
@@ -10915,7 +10461,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -10924,7 +10469,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -10934,7 +10478,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -10943,7 +10486,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -10951,14 +10493,12 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 				},
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -10990,7 +10530,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			},
@@ -10999,7 +10538,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -11014,7 +10552,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -11115,7 +10652,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -11125,7 +10661,6 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -11134,8 +10669,7 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -11143,7 +10677,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -11305,8 +10838,7 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-			"dev": true
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
 		},
 		"moment-mini": {
 			"version": "2.22.1",
@@ -11351,7 +10883,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-			"dev": true,
 			"requires": {
 				"duplexer2": "0.0.2"
 			}
@@ -11359,8 +10890,7 @@
 		"mustache": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
-			"dev": true
+			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -11503,8 +11033,7 @@
 		"node-addon-api": {
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
-			"integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==",
-			"dev": true
+			"integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
 		},
 		"node-cache": {
 			"version": "4.2.0",
@@ -11541,14 +11070,12 @@
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-			"dev": true
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 		},
 		"node-fetch-npm": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
 			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"json-parse-better-errors": "^1.0.0",
@@ -11559,7 +11086,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
 			"integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.3",
 				"graceful-fs": "^4.1.2",
@@ -11577,8 +11103,7 @@
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 				}
 			}
 		},
@@ -11677,7 +11202,6 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
 			"requires": {
 				"abbrev": "1"
 			}
@@ -11708,20 +11232,17 @@
 		"normalize-url": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-			"dev": true
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
 		},
 		"npm-bundled": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
-			"dev": true
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
 		},
 		"npm-lifecycle": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.1.tgz",
 			"integrity": "sha512-+Vg6I60Z75V/09pdcH5iUo/99Q/vop35PaI99elvxk56azSVVsdsSsS/sXqKDNwbRRNN1qSxkcO45ZOu0yOWew==",
-			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"graceful-fs": "^4.1.15",
@@ -11736,8 +11257,7 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -11745,7 +11265,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
 			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.6.0",
 				"osenv": "^0.1.5",
@@ -11756,8 +11275,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -11765,7 +11283,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
 			"integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
-			"dev": true,
 			"requires": {
 				"ignore-walk": "^3.0.1",
 				"npm-bundled": "^1.0.1"
@@ -11775,7 +11292,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
 			"integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
-			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
@@ -11785,8 +11301,7 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -11802,7 +11317,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -12089,7 +11603,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -12106,8 +11619,7 @@
 		"octokit-pagination-methods": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
-			"dev": true
+			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
 		},
 		"on-finished": {
 			"version": "2.3.0",
@@ -12183,7 +11695,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-			"dev": true,
 			"requires": {
 				"is-stream": "^1.0.1",
 				"readable-stream": "^2.0.1"
@@ -12193,7 +11704,6 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -12208,7 +11718,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -12239,7 +11748,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
 			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
-			"dev": true,
 			"requires": {
 				"macos-release": "^2.2.0",
 				"windows-release": "^3.1.0"
@@ -12254,7 +11762,6 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -12309,14 +11816,12 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-			"dev": true
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
 		},
 		"p-map-series": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
 			"integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
-			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -12324,14 +11829,12 @@
 		"p-pipe": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
-			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
-			"dev": true
+			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
 		},
 		"p-queue": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-4.0.0.tgz",
 			"integrity": "sha512-3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==",
-			"dev": true,
 			"requires": {
 				"eventemitter3": "^3.1.0"
 			}
@@ -12339,8 +11842,7 @@
 		"p-reduce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
-			"dev": true
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
 		},
 		"p-timeout": {
 			"version": "1.2.1",
@@ -12359,7 +11861,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-1.0.0.tgz",
 			"integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
-			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -12443,14 +11944,12 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -12461,14 +11960,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -12487,8 +11984,7 @@
 		"parse-node-version": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-			"dev": true
+			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
@@ -12499,7 +11995,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
 			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
-			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"protocols": "^1.4.0"
@@ -12509,7 +12004,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
 			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
-			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"normalize-url": "^3.3.0",
@@ -12591,7 +12085,6 @@
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"dev": true,
 			"requires": {
 				"through": "~2.3"
 			}
@@ -12643,7 +12136,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
 			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
-			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"load-json-file": "^1.1.0",
@@ -12655,7 +12147,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -12665,7 +12156,6 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -12678,7 +12168,6 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -12687,7 +12176,6 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -12695,14 +12183,12 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -12740,8 +12226,7 @@
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"pretty-bytes": {
 			"version": "5.2.0",
@@ -12777,7 +12262,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-			"dev": true,
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
@@ -12787,7 +12271,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
 			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-			"dev": true,
 			"requires": {
 				"read": "1"
 			}
@@ -12795,20 +12278,17 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-			"dev": true
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 		},
 		"protocols": {
 			"version": "1.4.7",
 			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
-			"dev": true
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
 		},
 		"protoduck": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
 			"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
-			"dev": true,
 			"requires": {
 				"genfun": "^5.0.0"
 			}
@@ -12888,8 +12368,7 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -12909,8 +12388,7 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-			"dev": true
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"railroad-diagrams": {
 			"version": "1.0.0",
@@ -12930,7 +12408,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -12940,8 +12417,7 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				}
 			}
 		},
@@ -13024,7 +12500,6 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
 			}
@@ -13042,7 +12517,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -13051,7 +12525,6 @@
 			"version": "2.0.13",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
 			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.1.2",
@@ -13063,8 +12536,7 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -13072,7 +12544,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
 			"integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
-			"dev": true,
 			"requires": {
 				"read-package-json": "^2.0.0",
 				"readdir-scoped-modules": "^1.0.0",
@@ -13112,7 +12583,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
 			"integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
-			"dev": true,
 			"requires": {
 				"debuglog": "^1.0.1",
 				"dezalgo": "^1.0.0",
@@ -13166,7 +12636,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-			"dev": true,
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
@@ -13202,7 +12671,6 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -13286,7 +12754,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -13364,7 +12831,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.2.tgz",
 			"integrity": "sha512-oJ6y7JcUJkblRGhMByGNcszeLgU0qDxNKFCiUZR1XyzHyVsev+Mxb1tyygxLd1ORsKee1SA5BInFdUwY64GE/A==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
 			}
@@ -13440,8 +12906,7 @@
 		"retry": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-			"dev": true
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -13734,8 +13199,7 @@
 		"sleep-promise": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
-			"integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U=",
-			"dev": true
+			"integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
@@ -13748,14 +13212,12 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-			"dev": true
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
 		"smart-buffer": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-			"dev": true
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -13871,7 +13333,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
 			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
-			"dev": true,
 			"requires": {
 				"ip": "^1.1.5",
 				"smart-buffer": "4.0.2"
@@ -13881,7 +13342,6 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
 			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
-			"dev": true,
 			"requires": {
 				"agent-base": "~4.2.1",
 				"socks": "~2.3.2"
@@ -13891,7 +13351,6 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
 					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
 					}
@@ -13902,7 +13361,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -13953,14 +13411,12 @@
 		"sparkles": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
-			"dev": true
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
-			"dev": true
+			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
 		},
 		"spawn-wrap": {
 			"version": "1.4.2",
@@ -14006,14 +13462,12 @@
 		"spdx-license-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz",
-			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0=",
-			"dev": true
+			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0="
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -14030,7 +13484,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -14172,7 +13625,6 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-			"dev": true,
 			"requires": {
 				"duplexer": "~0.1.1",
 				"through": "~2.3.4"
@@ -14311,8 +13763,7 @@
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -14323,7 +13774,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
 			"integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
-			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
 				"minimist": "^1.2.0",
@@ -14404,14 +13854,12 @@
 		"symbol": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
-			"dev": true
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
 		},
 		"sync": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/sync/-/sync-0.2.5.tgz",
 			"integrity": "sha1-ORC7m2ar7lZULi5w8M5UkDElLfY=",
-			"dev": true,
 			"requires": {
 				"fibers": ">=0.6"
 			}
@@ -14464,8 +13912,7 @@
 		"taffydb": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-			"dev": true
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
 		},
 		"taketalk": {
 			"version": "1.0.0",
@@ -14485,7 +13932,6 @@
 			"version": "4.4.10",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
 			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
-			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
@@ -14499,8 +13945,7 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -14545,14 +13990,12 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-			"dev": true
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -14566,7 +14009,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -14574,8 +14016,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -14639,8 +14080,7 @@
 		"text-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
-			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
-			"dev": true
+			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ=="
 		},
 		"text-hex": {
 			"version": "1.0.0",
@@ -14715,7 +14155,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
@@ -14724,8 +14163,7 @@
 		"time-stamp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-			"dev": true
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -14770,7 +14208,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1"
 			},
@@ -14779,7 +14216,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -14864,7 +14300,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -14872,26 +14307,22 @@
 		"tree-kill": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
-			"dev": true
+			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
 		},
 		"treeify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.0.1.tgz",
-			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8=",
-			"dev": true
+			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8="
 		},
 		"trim-newlines": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-			"dev": true
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-			"dev": true
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -14974,8 +14405,7 @@
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-			"dev": true
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"uglify-js": {
 			"version": "3.6.0",
@@ -14998,20 +14428,17 @@
 		"uid-number": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-			"dev": true
+			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
 		},
 		"umask": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
-			"dev": true
+			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
 		},
 		"underscore": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-			"dev": true
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -15068,7 +14495,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
 			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
-			"dev": true,
 			"requires": {
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"through2-filter": "^3.0.0"
@@ -15078,7 +14504,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
 					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
-					"dev": true,
 					"requires": {
 						"through2": "~2.0.0",
 						"xtend": "~4.0.0"
@@ -15090,7 +14515,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
 			"integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
-			"dev": true,
 			"requires": {
 				"os-name": "^3.0.0"
 			}
@@ -15098,8 +14522,7 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -15202,8 +14625,7 @@
 		"url-template": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
-			"dev": true
+			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
 		},
 		"url-to-options": {
 			"version": "1.0.1",
@@ -15244,7 +14666,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
 			"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
-			"dev": true,
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
@@ -15267,8 +14688,7 @@
 		"vali-date": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-			"dev": true
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -15283,7 +14703,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
 			}
@@ -15307,7 +14726,6 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
 			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
@@ -15356,7 +14774,6 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.2.0",
 				"glob-stream": "^5.3.2",
@@ -15380,14 +14797,12 @@
 				"first-chunk-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-					"dev": true
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
 				},
 				"readable-stream": {
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -15402,7 +14817,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -15411,7 +14825,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -15420,7 +14833,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-					"dev": true,
 					"requires": {
 						"first-chunk-stream": "^1.0.0",
 						"strip-bom": "^2.0.0"
@@ -15430,7 +14842,6 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -15463,7 +14874,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -15471,8 +14881,7 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-			"dev": true
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
 			"version": "4.35.2",
@@ -15654,7 +15063,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -15696,14 +15104,12 @@
 		"window-size": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
-			"dev": true
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
 		},
 		"windows-release": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
 			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
-			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
 			}
@@ -15849,7 +15255,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -15863,7 +15268,6 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -15871,8 +15275,7 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
 		},
@@ -15880,7 +15283,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
-			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -15889,8 +15291,7 @@
 		"xmlcreate": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
-			"integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
-			"dev": true
+			"integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA=="
 		},
 		"xregexp": {
 			"version": "4.2.4",

--- a/packages/cicero-core/test/contract.js
+++ b/packages/cicero-core/test/contract.js
@@ -35,4 +35,15 @@ describe('Contract', () => {
             contract.parse(sampleText);
         });
     });
+
+    describe('#generateText', () => {
+
+        it('should be able to roundtrip copyright-license natural language text', async function() {
+            const template = await Template.fromDirectory('./test/data/copyright-license', { skipUpdateExternalModels: true });
+            const contract = new Contract(template);
+            contract.parse(sampleText);
+            const nl = contract.generateText();
+            nl.should.equal(sampleText);
+        });
+    });
 });

--- a/packages/cicero-core/test/data/copyright-license/sample.txt
+++ b/packages/cicero-core/test/data/copyright-license/sample.txt
@@ -14,7 +14,7 @@ NOW, THEREFORE, in consideration of the mutual covenants, terms, and conditions 
 
 2. Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.
 
-3. Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of "one hundred US Dollars" (100.0 USD) upon execution of this Agreement, payable as follows: "bank transfer".  
+3. Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of "one hundred US Dollars" (100 USD) upon execution of this Agreement, payable as follows: "bank transfer".  
 
 4. General.
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #390 

Add support for Generate Text on nested clauses.

### Changes
- Generate text allows nested calls
  - Now handles ClauseBinding from the template AST
  - Roundtrip (parse/generateText) test on copyright notice

### Flags
- Would be useful to easily do roundtrip tests in cucumber for all templates

