### PR TITLE
feat(metadata): Add displayName property to template metadata

### DIFF
--- a/packages/cicero-core/src/metadata.js
+++ b/packages/cicero-core/src/metadata.js
@@ -90,7 +90,7 @@ class Metadata {
         this.ciceroVersion = packageJson.accordproject.cicero;
 
         if (!this.satisfiesCiceroVersion(ciceroVersion)){
-            const msg = `The template targets Cicero (${this.ciceroVersion}) but the Cicero version is ${ciceroVersion}.`;
+            const msg = `The template targets Cicero version ${this.ciceroVersion} but the current Cicero version is ${ciceroVersion}.`;
             Logger.error(msg);
             throw new Error(msg);
         }
@@ -132,6 +132,10 @@ class Metadata {
 
         if(packageJson.keywords && !Array.isArray(packageJson.keywords)) {
             throw new Error('keywords property in package.json must be an array.');
+        }
+
+        if(packageJson.displayName && packageJson.displayName.length > 214){
+            throw new Error('The template displayName property is limited to a maximum of 214 characters.');
         }
 
         this.readme = readme;
@@ -274,6 +278,25 @@ class Metadata {
      */
     getName() {
         return this.packageJson.name;
+    }
+
+    /**
+     * Returns the display name for this template.
+     * @return {string} the display name of the template
+     */
+    getDisplayName() {
+        // Fallback for packages that don't have a displayName property.
+        if(!this.packageJson.displayName) {
+            // Convert `acceptance-Of-Delivery` or `acceptanceOfDelivery` into `Acceptance Of Delivery`
+            return String(this.packageJson.name)
+                .split('-').join(' ')
+                .replace(/([a-z])([A-Z])/g, '$1 $2')
+                .replace(/([A-Z])([a-z])/g, ' $1$2')
+                .replace(/ +/g, ' ')
+                .replace(/^./, str => str.toUpperCase())
+                .trim();
+        }
+        return this.packageJson.displayName;
     }
 
     /**

--- a/packages/cicero-core/src/metadata.js
+++ b/packages/cicero-core/src/metadata.js
@@ -287,13 +287,11 @@ class Metadata {
     getDisplayName() {
         // Fallback for packages that don't have a displayName property.
         if(!this.packageJson.displayName) {
-            // Convert `acceptance-Of-Delivery` or `acceptanceOfDelivery` into `Acceptance Of Delivery`
+            // Convert `acceptance-of-delivery` or `acceptance_of_delivery` into `Acceptance Of Delivery`
             return String(this.packageJson.name)
-                .split('-').join(' ')
-                .replace(/([a-z])([A-Z])/g, '$1 $2')
-                .replace(/([A-Z])([a-z])/g, ' $1$2')
-                .replace(/ +/g, ' ')
-                .replace(/^./, str => str.toUpperCase())
+                .split(/_|-/)
+                .map(word => word.replace(/^./, str => str.toUpperCase()))
+                .join(' ')
                 .trim();
         }
         return this.packageJson.displayName;

--- a/packages/cicero-core/src/template.js
+++ b/packages/cicero-core/src/template.js
@@ -109,6 +109,14 @@ class Template {
     }
 
     /**
+     * Returns the display name for this template.
+     * @return {string} the display name of the template
+     */
+    getDisplayName() {
+        return this.getMetadata().getDisplayName();
+    }
+
+    /**
      * Returns the version for this template
      * @return {String} the version of this template. Use semver module
      * to parse.

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -178,7 +178,37 @@ describe('Metadata', () => {
                     ergo: '0.1.0',
                     language: 'ergo'
                 },
-            }, null, {})).should.throw('The template targets Cicero (0.0.0) but the Cicero version is ');
+            }, null, {})).should.throw('The template targets Cicero version 0.0.0 but the current Cicero version is ');
+        });
+
+        it('should get the displayName from packageJson', () => {
+            const displayName = 'My Display Name 👍 名称';
+            const metadata = new Metadata({
+                name: 'template',
+                version: '1.0.0',
+                accordproject: {
+                    template: 'clause',
+                    cicero:ciceroVersion,
+                    ergo: '0.1.0',
+                    language: 'ergo'
+                },
+                displayName,
+            }, null, {});
+            metadata.getDisplayName().should.equal(displayName);
+        });
+
+        it('should throw an error if the displayName is too long', () => {
+            return (() => new Metadata({
+                name: 'template',
+                version: '1.0.0',
+                accordproject: {
+                    template: 'clause',
+                    cicero:ciceroVersion,
+                    ergo: '0.1.0',
+                    language: 'ergo'
+                },
+                displayName: new Array(216).join('A'),
+            }, null, {})).should.throw('The template displayName property is limited to a maximum of 214 characters.');
         });
     });
 

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -197,22 +197,6 @@ describe('Metadata', () => {
             metadata.getDisplayName().should.equal(displayName);
         });
 
-        it('should get the displayName from packageJson', () => {
-            const displayName = 'My Display Name 👍 名称';
-            const metadata = new Metadata({
-                name: 'template',
-                version: '1.0.0',
-                accordproject: {
-                    template: 'clause',
-                    cicero:ciceroVersion,
-                    ergo: '0.1.0',
-                    language: 'ergo'
-                },
-                displayName,
-            }, null, {});
-            metadata.getDisplayName().should.equal(displayName);
-        });
-
         it('should get the displayName by falling back to the name in packageJson', () => {
             const metadata = new Metadata({
                 name: 'my-display_name',

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -197,6 +197,36 @@ describe('Metadata', () => {
             metadata.getDisplayName().should.equal(displayName);
         });
 
+        it('should get the displayName from packageJson', () => {
+            const displayName = 'My Display Name 👍 名称';
+            const metadata = new Metadata({
+                name: 'template',
+                version: '1.0.0',
+                accordproject: {
+                    template: 'clause',
+                    cicero:ciceroVersion,
+                    ergo: '0.1.0',
+                    language: 'ergo'
+                },
+                displayName,
+            }, null, {});
+            metadata.getDisplayName().should.equal(displayName);
+        });
+
+        it('should get the displayName by falling back to the name in packageJson', () => {
+            const metadata = new Metadata({
+                name: 'my-display_name',
+                version: '1.0.0',
+                accordproject: {
+                    template: 'clause',
+                    cicero:ciceroVersion,
+                    ergo: '0.1.0',
+                    language: 'ergo'
+                },
+            }, null, {});
+            metadata.getDisplayName().should.equal('My Display Name');
+        });
+
         it('should throw an error if the displayName is too long', () => {
             return (() => new Metadata({
                 name: 'template',

--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -114,6 +114,7 @@ describe('Template', () => {
             template.getMetadata().getRequest().should.not.be.null;
             template.getMetadata().getKeywords().should.not.be.null;
             template.getName().should.equal('latedeliveryandpenalty', options);
+            template.getDisplayName().should.equal('Latedeliveryandpenalty');
             template.getDescription().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 DAY of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a DAY is to be considered a full DAY. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 WEEK, the Buyer is entitled to terminate this Contract.');
             template.getVersion().should.equal('0.0.1');
             template.getMetadata().getSample().should.equal('Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.');
@@ -130,6 +131,7 @@ describe('Template', () => {
             template2.getMetadata().getKeywords().should.eql(template.getMetadata().getKeywords());
             template2.getMetadata().getSamples().should.eql(template.getMetadata().getSamples());
             template2.getHash().should.equal(template.getHash());
+            template.getDisplayName().should.equal('Latedeliveryandpenalty');
             const buffer2 = await template2.toArchive('ergo');
             buffer2.should.not.be.null;
         });


### PR DESCRIPTION
# Issue #388 
Adds a new metadata property to templates, called `displayName`. This allows a template author to specify a human-readable name for a template that is different from the template's computer-readable `name` property`.

### Changes
- The `displayName` property is defined within the `package.json` file for a template in a top-level attribute called `displayName`.
- The `displayName` property has a length restriction of 214 characters.

### Flags
- If a template does not provide `displayName` property, the fallback code attempts to construct one automatically from the `name` property by splitting the name at `-` and `_` characters. 
- Also addresses a typo in the Metadata constructor to make the Cicero version incompatibility error message more readable

### Related Issues
- Issue #388 