### PR TITLE
fix(401): Don't include inline source-maps in the distribution build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cicero",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2351,7 +2351,7 @@
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"requires": {
 				"acorn": "^3.0.4"
@@ -2359,7 +2359,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
 					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
@@ -2822,7 +2822,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -3567,7 +3567,7 @@
 		},
 		"bl": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -3693,7 +3693,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -3727,7 +3727,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -5064,7 +5064,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -5076,7 +5076,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -5481,7 +5481,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -5941,7 +5941,7 @@
 		},
 		"eslint": {
 			"version": "4.19.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"requires": {
 				"ajv": "^5.3.0",
@@ -8500,7 +8500,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -9861,7 +9861,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"requires": {
 						"cliui": "^4.0.0",
@@ -10778,7 +10778,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -11614,7 +11614,7 @@
 			"dependencies": {
 				"buffer": {
 					"version": "4.9.1",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+					"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 					"requires": {
 						"base64-js": "^1.0.2",
@@ -11869,7 +11869,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "^1.0.0"
@@ -11905,7 +11905,7 @@
 				},
 				"yargs": {
 					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
 					"requires": {
 						"camelcase": "^2.0.1",
@@ -13223,7 +13223,7 @@
 		},
 		"regexpp": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
 			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
 		},
 		"regexpu-core": {
@@ -13646,7 +13646,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -14170,7 +14170,7 @@
 		},
 		"stream-combiner": {
 			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
 			"dev": true,
 			"requires": {
@@ -14633,7 +14633,7 @@
 		},
 		"text-encoding": {
 			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
 		"text-extensions": {
@@ -16570,7 +16570,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",

--- a/packages/cicero-core/.babelrc
+++ b/packages/cicero-core/.babelrc
@@ -10,5 +10,12 @@
             }
         ]
     ],
-    "plugins": ["istanbul","@babel/plugin-proposal-object-rest-spread"]
+    "env": {
+        "production": {
+            "plugins": ["@babel/plugin-proposal-object-rest-spread"]
+        },
+        "development": {
+            "plugins": ["istanbul","@babel/plugin-proposal-object-rest-spread"]
+        }
+      }
 }

--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -17,8 +17,9 @@
   "scripts": {
     "webpack": "webpack --config webpack.config.js --mode production",
     "build": "babel src -d lib --copy-files && nearleyc ./src/tdl.ne -o ./lib/tdl.js && node scripts/nunjucks-precompile.js",
+    "build:dist": "NODE_ENV=production babel src -d lib --copy-files && nearleyc ./src/tdl.ne -o ./lib/tdl.js && node scripts/nunjucks-precompile.js",
     "build:watch": "babel src -d lib --copy-files --watch",
-    "prepublishOnly": "npm run build && npm run webpack",
+    "prepublishOnly": "npm run build:dist && npm run webpack",
     "prepare": "npm run build",
     "pretest": "npm run lint && npm run build",
     "lint": "eslint .",
@@ -71,10 +72,8 @@
   },
   "dependencies": {
     "@accordproject/ergo-compiler": "0.9.4",
-    "acorn": "5.7.3",
     "axios": "0.19.0",
     "debug": "4.1.0",
-    "fast-safe-stringify": "2.0.5",
     "ietf-language-tag-regex": "0.0.5",
     "json-stable-stringify": "1.0.1",
     "jszip": "3.2.1",
@@ -87,7 +86,6 @@
     "request-promise-native": "1.0.7",
     "semver": "6.2.0",
     "uuid": "3.3.2",
-    "winston": "3.2.1",
     "xregexp": "4.2.4"
   },
   "license-check-config": {


### PR DESCRIPTION
# Issue 401
The inclusion of inline source-maps can cause problems when using cicero-core as a dependency in projects that use tools that process source-maps but don't have access to the source files. We don't bundle the source files in the distribution so source maps have limited use.

Including the source-maps inline also bloats the distribution files a little (~20Kb).

### Changes
- Adds babel environment configs that allow a different set of plugins to retain the source maps during tests and development but to remove them when building for distribution.
- Also removes a few unused dependencies. 

### Flags
- There is a small risk that the `development` and `production` babel configs diverge and we see different behaviour in production. Maintainers (@jeromesimeon, @dselman, @irmerk) should watch for this when reviewing future PRs.
- This change may also mean that stack traces from errors in production code are harder to debug because there is no source-map provided. 

### Related Issues
- As reported by @j4m3sb0mb in #401,