### PR TITLE
chore(ci): Add Windows CI build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.js text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '8.16'
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8.16'
+  - '8'
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install: |
 script: if [ $TRAVIS_OS_NAME = 'windows' ]; then npm run test:cli 2>&1; else npm run test 2>&1; fi 
 deploy:
     provider: script
-    script: if [ $TRAVIS_OS_NAME = 'windows' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then bash ./.travis/deploy.sh; fi
+    script: if [ $TRAVIS_OS_NAME = 'linux' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then bash ./.travis/deploy.sh; fi
     skip_cleanup: true
     on:
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install: |
   npm install -g lerna@^2.11.0
   lerna bootstrap 2>&1
   date
-script: if [ $TRAVIS_OS_NAME = 'windows' ]; then npm run test:cli 2>&1; else npm run test 2>&1; fi 
+script: bash ./.travis/test.sh
 deploy:
     provider: script
     script: if [ $TRAVIS_OS_NAME = 'linux' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then bash ./.travis/deploy.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install: |
 install: |
   set -e
   date
-  npm install -g lerna@^2.11.0
+  npm install -g lerna@^3.16.4
   lerna bootstrap 2>&1
   date
 script: bash ./.travis/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
       all_branches: true
       repo: accordproject/cicero
 after_failure: tail -n +1 -- /home/travis/.npm/_logs/*-debug.log
-after_success: if [ $TRAVIS_REPO_SLUG = 'accordproject/cicero' ]; then npm run coverage; fi
+after_success: if [ $TRAVIS_OS_NAME = 'linux' ] && [ $TRAVIS_REPO_SLUG = 'accordproject/cicero' ]; then npm run coverage; fi
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
 node_js:
   - '8'
-dist: trusty
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: windows
 before_install: |
   set -e
   export PATH="./$HOME/node_modules/.bin:$PATH"
@@ -13,11 +17,10 @@ install: |
   npm install -g lerna@^2.11.0
   lerna bootstrap 2>&1
   date
-script: npm run test 2>&1
+script: if [ $TRAVIS_OS_NAME = 'windows' ]; then lerna run test --scope @accordproject/cicero-cli; else lerna run test; fi
 deploy:
     provider: script
-    script: 
-      - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./.travis/deploy.sh; fi'
+    script: if [ $TRAVIS_OS_NAME = 'windows' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then bash ./.travis/deploy.sh; fi
     skip_cleanup: true
     on:
       all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install: |
   npm install -g lerna@^2.11.0
   lerna bootstrap 2>&1
   date
-script: if [ $TRAVIS_OS_NAME = 'windows' ]; then lerna run test --scope @accordproject/cicero-cli; else lerna run test; fi
+script: if [ $TRAVIS_OS_NAME = 'windows' ]; then npm run test:cli 2>&1; else npm run test 2>&1; fi 
 deploy:
     provider: script
     script: if [ $TRAVIS_OS_NAME = 'windows' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then bash ./.travis/deploy.sh; fi
@@ -26,8 +26,7 @@ deploy:
       all_branches: true
       repo: accordproject/cicero
 after_failure: tail -n +1 -- /home/travis/.npm/_logs/*-debug.log
-after_success:
-  - 'if [ "$TRAVIS_REPO_SLUG" = "accordproject/cicero" ]; then npm run coverage; fi'
+after_success: if [ $TRAVIS_REPO_SLUG = 'accordproject/cicero' ]; then npm run coverage; fi
 cache:
   directories:
   - node_modules

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -20,16 +20,6 @@
 set -ev
 set -o pipefail
 
-# Bring in the standard set of script utilities
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-source ${DIR}/.travis/base.sh
-
 # ----
 
-if [ $TRAVIS_OS_NAME = 'windows' ]; then 
-    npm run test:cli 2>&1; 
-else 
-    npm run test 2>&1;
-fi 
-
-_exit "All complete" 0
+npm run test 2>&1

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -27,7 +27,7 @@ source ${DIR}/.travis/base.sh
 
 # ----
 
-if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then 
+if [ $TRAVIS_OS_NAME = 'windows' ]; then 
     npm run test:cli; 
 else 
     npm run test;

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script for the deploy phase, to push NPM modules, docker images and
+# cloud playground images
+
+# Exit on first error, print all commands.
+set -ev
+set -o pipefail
+
+# Bring in the standard set of script utilities
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+source ${DIR}/.travis/base.sh
+
+# ----
+
+if [ $TRAVIS_OS_NAME = 'windows' ]; then 
+    npm run test:cli 2>&1; 
+else 
+    npm run test 2>&1;
+fi 
+
+_exit "All complete" 0

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -27,10 +27,10 @@ source ${DIR}/.travis/base.sh
 
 # ----
 
-if [ $TRAVIS_OS_NAME = 'windows' ]; then 
-    npm run test:cli 2>&1; 
+if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then 
+    npm run test:cli; 
 else 
-    npm run test 2>&1;
+    npm run test;
 fi 
 
 _exit "All complete" 0

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -20,6 +20,17 @@
 set -ev
 set -o pipefail
 
+
+# Bring in the standard set of script utilities
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+source ${DIR}/.travis/base.sh
+
 # ----
 
-npm run test 2>&1
+if [ $TRAVIS_OS_NAME = 'windows' ]; then 
+    npm run test:cli 2>&1; 
+else 
+    npm run test 2>&1;
+fi 
+
+_exit "All complete" 0

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,8 +2,8 @@
     "source": {
         "include": ["packages"],
         "exclude": ["packages/generator-cicero-template", "packages/cicero-core/umd","packages/cicero-core/lib"],
-        "includePattern": ".+\\.js(doc|x)?$",
-        "excludePattern": ".?\/(coverage|out|node_modules|test)\/.+"
+        "includePattern": ".+[\\/].js(doc|x)?$",
+        "excludePattern": ".?[\\/](coverage|out|node_modules|test)[\\/].+"
     },
     "recurseDepth": 10,
     "tags": {

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,7 +2,7 @@
     "source": {
         "include": ["packages"],
         "exclude": ["packages/generator-cicero-template", "packages/cicero-core/umd","packages/cicero-core/lib"],
-        "includePattern": ".+[\\/].js(doc|x)?$",
+        "includePattern": ".+\\.js(doc|x)?$",
         "excludePattern": ".?[\\/](coverage|out|node_modules|test)[\\/].+"
     },
     "recurseDepth": 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "cicero",
+	"version": "0.13.4",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@accordproject/ergo-compiler": {
 			"version": "0.9.4",
@@ -862,6 +864,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.0.tgz",
 			"integrity": "sha512-bfrqZ0v+Il5TJBsgF2oyepeJg34K2pBItapzP+UT1QMIGpUh/Zc1pQql4jrafamZTqP3ZvdJxaElat8B5K3ICA==",
+			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"aproba": "^2.0.0",
@@ -873,7 +876,8 @@
 				"aproba": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"dev": true
 				}
 			}
 		},
@@ -881,6 +885,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmpublish/-/libnpmpublish-1.2.0.tgz",
 			"integrity": "sha512-sezhX9FSnPIyrBBvxVocVJVO1uIWPczf6rOmUZSntCWfQMraO8pWTFlDJbroFqPbEqFFHf3eyw8NQ0Eb7OLd1g==",
+			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"aproba": "^2.0.0",
@@ -896,12 +901,14 @@
 				"aproba": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"dev": true
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -909,6 +916,7 @@
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/@evocateur/npm-registry-fetch/-/npm-registry-fetch-3.9.1.tgz",
 			"integrity": "sha512-6v1bHbcAypQ+te/1RGSNL4JkK6mcMtcZrUusqo5iKRtYSAig9UJXlOaCcBR+eLywt2DQMNpEwAj24jwWDX5G/w==",
+			"dev": true,
 			"requires": {
 				"JSONStream": "^1.3.4",
 				"bluebird": "^3.5.1",
@@ -923,6 +931,7 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.0.tgz",
 			"integrity": "sha512-nKx8EPxXhzqNfePbqC6603z7Kkf6GBS2q+SNGtBS/bCgS5Q+p3OVR6MXKOkpvC3WHse98W2WLu8QaV9axtfxyw==",
+			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"bluebird": "^3.5.3",
@@ -957,6 +966,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -964,12 +974,14 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -982,6 +994,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.15.0.tgz",
 			"integrity": "sha512-+KrG4GFy/6FISZ+DwWf5Fj5YB4ESa4VTnSn/ujf3VEda6dxngHPN629j+TcPbsdOxUYVah+HuZbC/B8NnkrKpQ==",
+			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.0",
 				"@lerna/bootstrap": "3.15.0",
@@ -998,7 +1011,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1006,6 +1020,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.14.0.tgz",
 			"integrity": "sha512-RlBkQVNTqk1qvn6PFWiWNiskllUHh6tXbTVm43mZRNd+vhAyvrQC8RWJxH0ECVvnFAt9rSNGRIVbEJ31WnNQLg==",
+			"dev": true,
 			"requires": {
 				"@lerna/package-graph": "3.14.0",
 				"npmlog": "^4.1.2"
@@ -1015,6 +1030,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.15.0.tgz",
 			"integrity": "sha512-4AxsPKKbgj2Ju03qDddQTpOHvpqnwd0yaiEU/aCcWv/4tDTe79NqUne2Z3+P2WZY0Zzb8+nUKcskwYBMTeq+Mw==",
+			"dev": true,
 			"requires": {
 				"@lerna/batch-packages": "3.14.0",
 				"@lerna/command": "3.15.0",
@@ -1045,7 +1061,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1053,6 +1070,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.15.0.tgz",
 			"integrity": "sha512-Hns1ssI9T9xOTGVc7PT2jUaqzsSkxV3hV/Y7iFO0uKTk+fduyTwGTHU9A/ybQ/xi/9iaJbvaXyjxKiGoEnzmhg==",
+			"dev": true,
 			"requires": {
 				"@lerna/collect-updates": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1065,6 +1083,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.14.2.tgz",
 			"integrity": "sha512-7safqxM/MYoAoxZxulUDtIJIbnBIgo0PB/FHytueG+9VaX7GMnDte2Bt1EKa0dz2sAyQdmQ3Q8ZXpf/6JDjaeg==",
+			"dev": true,
 			"requires": {
 				"@lerna/collect-uncommitted": "3.14.2",
 				"@lerna/describe-ref": "3.14.2",
@@ -1075,6 +1094,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.14.2.tgz",
 			"integrity": "sha512-xnq+W5yQb6RkwI0p16ZQnrn6HkloH/MWTw4lGE1nKsBLAUbmSU5oTE93W1nrG0X3IMF/xWc9UYvNdUGMWvZZ4w==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
 				"execa": "^1.0.0",
@@ -1085,6 +1105,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.15.0.tgz",
 			"integrity": "sha512-D1BN7BnJk6YjrSR7E7RiCmWiFVWDo3L+OSe6zDq6rNNYexPBtSi2JOCeF/Dibi3jd2luVu0zkVpUtuEEdPiD+A==",
+			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1100,6 +1121,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
 			"integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+			"dev": true,
 			"requires": {
 				"@lerna/global-options": "3.13.0",
 				"dedent": "^0.7.0",
@@ -1110,17 +1132,20 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -1130,6 +1155,7 @@
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.2.0",
@@ -1149,6 +1175,7 @@
 					"version": "11.1.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -1160,6 +1187,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.14.2.tgz",
 			"integrity": "sha512-4EkQu4jIOdNL2BMzy/N0ydHB8+Z6syu6xiiKXOoFl0WoWU9H1jEJCX4TH7CmVxXL1+jcs8FIS2pfQz4oew99Eg==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"chalk": "^2.3.1",
@@ -1171,6 +1199,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.14.2.tgz",
 			"integrity": "sha512-+zSQ2ZovH8Uc0do5dR+sk8VvRJc6Xl+ZnJJGESIl17KSpEw/lVjcOyt6f3BP+WHn+iSOjMWcGvUVA601FIEdZw==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/describe-ref": "3.14.2",
@@ -1182,7 +1211,8 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -1190,6 +1220,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.15.0.tgz",
 			"integrity": "sha512-dZqr4rKFN+veuXakIQ1DcGUpzBgcWKaYFNN4O6/skOdVQaEfGefzo1sZET+q7k/BkypxkhXHXpv5UqqSuL/EHQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/package-graph": "3.14.0",
@@ -1207,6 +1238,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.14.0.tgz",
 			"integrity": "sha512-hGZ2qQZ9uEGf2eeIiIpEodSs9Qkkf/2uYEtNT7QN1RYISPUh6/lKGBssc5dpbCF64aEuxmemWLdlDf1ogG6++w==",
+			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
 				"conventional-changelog-angular": "^5.0.3",
@@ -1223,12 +1255,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1236,6 +1270,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.15.0.tgz",
 			"integrity": "sha512-doXGt0HTwTQl8GkC2tOrraA/5OWbz35hJqi7Dsl3Fl0bAxiv9XmF3LykHFJ+YTDHfGpdoJ8tKu66f/VKP16G0w==",
+			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.0",
 				"@lerna/child-process": "3.14.2",
@@ -1260,17 +1295,20 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -1278,6 +1316,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.14.0.tgz",
 			"integrity": "sha512-Kw51HYOOi6UfCKncqkgEU1k/SYueSBXgkNL91FR8HAZH7EPSRTEtp9mnJo568g0+Hog5C+3cOaWySwhHpRG29A==",
+			"dev": true,
 			"requires": {
 				"cmd-shim": "^2.0.2",
 				"fs-extra": "^7.0.0",
@@ -1288,6 +1327,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.14.2.tgz",
 			"integrity": "sha512-qa5pzDRK2oBQXNjyRmRnN7E8a78NMYfQjjlRFB0KNHMsT6mCiL9+8kIS39sSE2NqT8p7xVNo2r2KAS8R/m3CoQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"npmlog": "^4.1.2"
@@ -1297,6 +1337,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.15.0.tgz",
 			"integrity": "sha512-N1Pr0M554Bt+DlVoD+DXWGh92gcq6G9icn8sH5GSqfwi0XCpPNJ2i1BNEZpUQ6ulLWOMa1YHR4PypPxecRGBjA==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1308,6 +1349,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.15.0.tgz",
 			"integrity": "sha512-YuXPd64TNG9wbb3lRvyMARQbdlbMZ1bJZ+GCm0enivnIWUyg0qtBDcfPY2dWpIgOif04zx+K/gmOX4lCaGM4UQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1321,6 +1363,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.14.2.tgz",
 			"integrity": "sha512-Ct8oYvRttbYB9JalngHhirb8o9ZVyLm5a9MpXNevXoHiu6j0vNhI19BQCwNnrL6wZvEHJnzPuUl/jO23tWxemg==",
+			"dev": true,
 			"requires": {
 				"@lerna/collect-updates": "3.14.2",
 				"@lerna/filter-packages": "3.13.0",
@@ -1331,6 +1374,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
 			"integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
 				"multimatch": "^2.1.0",
@@ -1341,6 +1385,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
 			"integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
+			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1349,6 +1394,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
 			"integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
 				"ssri": "^6.0.1",
@@ -1359,6 +1405,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.14.2.tgz",
 			"integrity": "sha512-+2Xh7t4qVmXiXE2utPnh5T7YwSltG74JP7c+EiooRY5+3zjh9MpPOcTKxVY3xKclzpsyXMohk2KpTF4tzA5rrg==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@octokit/plugin-enterprise-rest": "^2.1.1",
@@ -1371,6 +1418,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/gitlab-client/-/gitlab-client-3.15.0.tgz",
 			"integrity": "sha512-OsBvRSejHXUBMgwWQqNoioB8sgzL/Pf1pOUhHKtkiMl6aAWjklaaq5HPMvTIsZPfS6DJ9L5OK2GGZuooP/5c8Q==",
+			"dev": true,
 			"requires": {
 				"node-fetch": "^2.5.0",
 				"npmlog": "^4.1.2",
@@ -1380,12 +1428,14 @@
 		"@lerna/global-options": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
-			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ=="
+			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
+			"dev": true
 		},
 		"@lerna/has-npm-version": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.14.2.tgz",
 			"integrity": "sha512-cG+z5bB8JPd5f+nT2eLN2LmKg06O11AxlnUxgw2W7cLyc7cnsmMSp/rxt2JBMwW2r4Yn+CLLJIRwJZ2Es8jFSw==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"semver": "^5.5.0"
@@ -1394,7 +1444,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1402,6 +1453,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.15.0.tgz",
 			"integrity": "sha512-4GKQgeTXBTwMbZNkYyPdQIVA41HIISD7D6XRNrDaG0falUfvoPsknijQPCBmGqeh66u1Fcn2+4lkL3OCTj2FMg==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1417,6 +1469,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.15.0.tgz",
 			"integrity": "sha512-VOqH6kFbFtfUbXxhSqXKY6bjnVp9nLuLRI6x9tVHOANX2LmSlXm17OUGBnNt+eM4uJLuiUsAR8nTlpCiz//lPQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/command": "3.15.0",
@@ -1429,6 +1482,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.15.0.tgz",
 			"integrity": "sha512-yKHuifADINobvDOLljBGkVGpVwy6J3mg5p9lQXBdOLXBoIKC8o/UKBR9JvZMFvT/Iy6zn6FPy1v5lz9iU1Ib0Q==",
+			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/package-graph": "3.14.0",
@@ -1440,7 +1494,8 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -1448,6 +1503,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.15.0.tgz",
 			"integrity": "sha512-8SvxnlfAnbEzQDf2NL0IxWyUuqWTykF9cHt5/f5TOzgESClpaOkDtqwh/UlE8nVTzWMnxnQUPQi3UTKyJD3i3g==",
+			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1459,6 +1515,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.14.0.tgz",
 			"integrity": "sha512-ZK44Mo8xf/N97eQZ236SPSq0ek6+gk4HqHIx05foEMZVV1iIDH4a/nblLsJNjGQVsIdMYFPaqNJ0z+ZQfiJazQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/query-graph": "3.14.0",
 				"chalk": "^2.3.1",
@@ -1469,6 +1526,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
 			"integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
+			"dev": true,
 			"requires": {
 				"byte-size": "^4.0.3",
 				"columnify": "^1.5.4",
@@ -1480,6 +1538,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
 			"integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
+			"dev": true,
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
@@ -1488,7 +1547,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -1496,6 +1556,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.15.0.tgz",
 			"integrity": "sha512-lnbdwc4Ebs7/EI9fTIgbH3dxXnP+SuCcGhG7P5ZjOqo67SY09sRZGcygEzabpvIwXvKpBF8vCd4xxzjnF2u+PA==",
+			"dev": true,
 			"requires": {
 				"@evocateur/npm-registry-fetch": "^3.9.1",
 				"@lerna/otplease": "3.14.0",
@@ -1508,6 +1569,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.14.2.tgz",
 			"integrity": "sha512-JYJJRtLETrGpcQZa8Rj16vbye399RqnaXmJlZuZ2twjJ2DYVYtwkfsGEOdvdaKw5KVOEpWcAxBA9OMmKQtCLQw==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/get-npm-exec-opts": "3.13.0",
@@ -1522,6 +1584,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.15.0.tgz",
 			"integrity": "sha512-G7rcNcSGjG0La8eHPXDvCvoNXbwNnP6XJ+GPh3CH5xiR/nikfLOa+Bfm4ytdjVWWxnKfCT4qyMTCoV1rROlqQQ==",
+			"dev": true,
 			"requires": {
 				"@evocateur/libnpmpublish": "^1.2.0",
 				"@lerna/otplease": "3.14.0",
@@ -1537,7 +1600,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -1545,6 +1609,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.14.2.tgz",
 			"integrity": "sha512-LbVFv+nvAoRTYLMrJlJ8RiakHXrLslL7Jp/m1R18vYrB8LYWA3ey+nz5Tel2OELzmjUiemAKZsD9h6i+Re5egg==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"@lerna/get-npm-exec-opts": "3.13.0",
@@ -1555,6 +1620,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/otplease/-/otplease-3.14.0.tgz",
 			"integrity": "sha512-rYAWzaYZ81bwnrmTkYWGgcc13bl/6DlG7pjWQWNGAJNLzO5zzj0xmXN5sMFJnNvDpSiS/ZS1sIuPvb4xnwLUkg==",
+			"dev": true,
 			"requires": {
 				"@lerna/prompt": "3.13.0",
 				"figgy-pudding": "^3.5.1"
@@ -1564,6 +1630,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
 			"integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
+			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1572,6 +1639,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.14.2.tgz",
 			"integrity": "sha512-b3LnJEmIml3sDj94TQT8R+kVyrDlmE7Su0WwcBYZDySXPMSZ38WA2/2Xjy/EWhXlFxp/nUJKyUG78nDrZ/00Uw==",
+			"dev": true,
 			"requires": {
 				"@lerna/get-packed": "3.13.0",
 				"@lerna/package": "3.14.2",
@@ -1587,6 +1655,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.14.2.tgz",
 			"integrity": "sha512-YR/+CzYdufJYfsUlrfuhTjA35iSZpXK7mVOZmeR9iRWhSaqesm4kq2zfxm9vCpZV2oAQQZOwi4eo5h0rQBtdiw==",
+			"dev": true,
 			"requires": {
 				"load-json-file": "^4.0.0",
 				"npm-package-arg": "^6.1.0",
@@ -1597,6 +1666,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.14.0.tgz",
 			"integrity": "sha512-dNpA/64STD5YXhaSlg4gT6Z474WPJVCHoX1ibsVIFu0fVgH609Y69bsdmbvTRdI7r6Dcu4ZfGxdR636RTrH+Eg==",
+			"dev": true,
 			"requires": {
 				"@lerna/prerelease-id-from-version": "3.14.0",
 				"@lerna/validation-error": "3.13.0",
@@ -1608,7 +1678,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1616,6 +1687,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/prerelease-id-from-version/-/prerelease-id-from-version-3.14.0.tgz",
 			"integrity": "sha512-Ap3Z/dNhqQuSrKmK+JmzYvQYI2vowxHvUVxZJiDVilW8dyNnxkCsYFmkuZytk5sxVz4VeGLNPS2RSsU5eeSS+Q==",
+			"dev": true,
 			"requires": {
 				"semver": "^5.5.0"
 			},
@@ -1623,7 +1695,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1631,6 +1704,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.15.0.tgz",
 			"integrity": "sha512-eNGUWiMbQ9kh9kGkomtMnsLypS0rfLqxKgZP2+VnNVtIXjnLv4paeTm+1lkL+naNJUwhnpMk2NSLEeoxT/20QA==",
+			"dev": true,
 			"requires": {
 				"@lerna/package": "3.14.2",
 				"@lerna/validation-error": "3.13.0",
@@ -1649,7 +1723,8 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
 				}
 			}
 		},
@@ -1657,6 +1732,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
 			"integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
+			"dev": true,
 			"requires": {
 				"inquirer": "^6.2.0",
 				"npmlog": "^4.1.2"
@@ -1666,6 +1742,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -1675,12 +1752,14 @@
 				"chardet": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+					"dev": true
 				},
 				"external-editor": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
 					"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+					"dev": true,
 					"requires": {
 						"chardet": "^0.7.0",
 						"iconv-lite": "^0.4.24",
@@ -1691,6 +1770,7 @@
 					"version": "6.4.1",
 					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
 					"integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.2.0",
 						"chalk": "^2.4.2",
@@ -1711,6 +1791,7 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -1720,6 +1801,7 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -1730,6 +1812,7 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					},
@@ -1737,7 +1820,8 @@
 						"ansi-regex": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
 						}
 					}
 				}
@@ -1747,6 +1831,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.15.0.tgz",
 			"integrity": "sha512-6tRRBJ8olLSXfrUsR4f7vSfx0cT1oPi6/v06yI3afDSsUX6eQ3ooZh7gMY4RWmd+nM/IJHTUzhlKF6WhTvo+9g==",
+			"dev": true,
 			"requires": {
 				"@evocateur/libnpmaccess": "^3.1.0",
 				"@evocateur/npm-registry-fetch": "^3.9.1",
@@ -1782,7 +1867,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -1790,6 +1876,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
 			"integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1798,6 +1885,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.14.0.tgz",
 			"integrity": "sha512-6YTh3vDMW2hUxHdKeRvx4bosc9lZClKaN+DzC1XKTkwDbWrsjmEzLcemKL6QnyyeuryN2f/eto7P9iSe3z3pQQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/package-graph": "3.14.0",
 				"figgy-pudding": "^3.5.1"
@@ -1807,6 +1895,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
 			"integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
+			"dev": true,
 			"requires": {
 				"fs-extra": "^7.0.0",
 				"npmlog": "^4.1.2",
@@ -1817,6 +1906,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.14.2.tgz",
 			"integrity": "sha512-eFNkZsy44Bu9v1Hrj5Zk6omzg8O9h/7W6QYK1TTUHeyrjTEwytaNQlqF0lrTLmEvq55sviV42NC/8P3M2cvq8Q==",
+			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"npmlog": "^4.1.2",
@@ -1828,6 +1918,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.15.0.tgz",
 			"integrity": "sha512-KQBkzZYoEKmzILKjbjsm1KKVWFBXwAdwzqJWj/lfxxd3V5LRF8STASk8aiw8bSpB0bUL9TU/pbXakRxiNzjDwQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/command": "3.15.0",
 				"@lerna/filter-options": "3.14.2",
@@ -1843,6 +1934,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.14.0.tgz",
 			"integrity": "sha512-GUM3L9MzGRSW0WQ8wbLW1+SYStU1OFjW0GBzShhBnFrO4nGRrU7VchsLpcLu0hk2uCzyhsrDKzifEdOdUyMoEQ==",
+			"dev": true,
 			"requires": {
 				"@lerna/npm-conf": "3.13.0",
 				"figgy-pudding": "^3.5.1",
@@ -1854,6 +1946,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
 			"integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
+			"dev": true,
 			"requires": {
 				"p-map": "^1.2.0",
 				"p-map-series": "^1.0.0"
@@ -1863,6 +1956,7 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.14.0.tgz",
 			"integrity": "sha512-y+KBpC1YExFzGynovt9MY4O/bc3RrJaKeuXieiPfKGKxrdtmZe/r33oj/xePTXZq65jnw3SaU3H8S5CrrdkwDg==",
+			"dev": true,
 			"requires": {
 				"@lerna/query-graph": "3.14.0",
 				"figgy-pudding": "^3.5.1",
@@ -1873,6 +1967,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.14.2.tgz",
 			"integrity": "sha512-tqMwuWi6z1da0AFFbleWyu3H9fqayiV50rjj4anFTfayel9jSjlA1xPG+56sGIP6zUUNuUSc9kLh7oRRmlauoA==",
+			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "3.14.0",
 				"@lerna/package": "3.14.2",
@@ -1884,6 +1979,7 @@
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.14.2.tgz",
 			"integrity": "sha512-Ox7WKXnHZ7IwWlejcCq3n0Hd/yMLv8AwIryhvWxM/RauAge+ML4wg578SsdCyKob8ecgm/R0ytHiU06j81iL1w==",
+			"dev": true,
 			"requires": {
 				"@lerna/create-symlink": "3.14.0",
 				"@lerna/resolve-symlink": "3.13.0",
@@ -1897,12 +1993,14 @@
 		"@lerna/timer": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
-			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw=="
+			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
+			"dev": true
 		},
 		"@lerna/validation-error": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
 			"integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
+			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2"
 			}
@@ -1911,6 +2009,7 @@
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.15.0.tgz",
 			"integrity": "sha512-vReYX1NMXZ9PwzTZm97wAl/k3bmRnRZhnQi3mq/m49xTnDavq7p4sbUdFpvu8cVZNKnYS02pNIVGHrQw+K8ZCw==",
+			"dev": true,
 			"requires": {
 				"@lerna/check-working-tree": "3.14.2",
 				"@lerna/child-process": "3.14.2",
@@ -1941,12 +2040,14 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -1954,6 +2055,7 @@
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
 			"integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
+			"dev": true,
 			"requires": {
 				"npmlog": "^4.1.2",
 				"write-file-atomic": "^2.3.0"
@@ -1977,6 +2079,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.2.0.tgz",
 			"integrity": "sha512-g4r1MKr8GJ8qubJQp3HP3JrxDY+ZeVqjYBTgtu1lPEDLhfQDY6rOhyZOoHKOw+gaIF6aAcmuvPPNZUro2OwmOg==",
+			"dev": true,
 			"requires": {
 				"deepmerge": "3.3.0",
 				"is-plain-object": "^3.0.0",
@@ -1988,6 +2091,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
 					"requires": {
 						"isobject": "^4.0.0"
 					}
@@ -1995,19 +2099,22 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
 				}
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
-			"integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw=="
+			"integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==",
+			"dev": true
 		},
 		"@octokit/request": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-4.1.1.tgz",
 			"integrity": "sha512-LOyL0i3oxRo418EXRSJNk/3Q4I0/NKawTn6H/CQp+wnrG1UFLGu080gSsgnWobhPo5BpUNgSQ5BRk5FOOJhD1Q==",
+			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^5.1.0",
 				"@octokit/request-error": "^1.0.1",
@@ -2022,6 +2129,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+					"dev": true,
 					"requires": {
 						"isobject": "^4.0.0"
 					}
@@ -2029,7 +2137,8 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
 				}
 			}
 		},
@@ -2037,6 +2146,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
 			"integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+			"dev": true,
 			"requires": {
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
@@ -2046,6 +2156,7 @@
 			"version": "16.28.2",
 			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.2.tgz",
 			"integrity": "sha512-csuYiHvJ1P/GFDadVn0QhwO83R1+YREjcwCY7ZIezB6aJTRIEidJZj+R7gAkUhT687cqYb4cXTZsDVu9F+Fmug==",
+			"dev": true,
 			"requires": {
 				"@octokit/request": "^4.0.1",
 				"@octokit/request-error": "^1.0.2",
@@ -2273,6 +2384,7 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
 			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
 			"requires": {
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
@@ -2286,7 +2398,8 @@
 		"abbrev": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -2304,7 +2417,7 @@
 		},
 		"acorn-jsx": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"requires": {
 				"acorn": "^3.0.4"
@@ -2312,7 +2425,7 @@
 			"dependencies": {
 				"acorn": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
 					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
 				}
 			}
@@ -2321,6 +2434,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -2329,6 +2443,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
 			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
 			}
@@ -2358,6 +2473,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true,
 			"optional": true
 		},
 		"ansi-colors": {
@@ -2374,6 +2490,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
 			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
 			"requires": {
 				"ansi-wrap": "0.1.0"
 			}
@@ -2394,7 +2511,8 @@
 		"ansi-wrap": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
 		},
 		"any-promise": {
 			"version": "1.3.0",
@@ -2521,6 +2639,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -2530,6 +2649,7 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -2544,6 +2664,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -2581,7 +2702,8 @@
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -2596,7 +2718,8 @@
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"dev": true
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -2660,7 +2783,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"requires": {
 						"inherits": "2.0.1"
@@ -2726,7 +2849,8 @@
 		"atob-lite": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -2769,7 +2893,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -2967,12 +3091,12 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
@@ -3204,7 +3328,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				},
 				"regexpu-core": {
@@ -3219,12 +3343,12 @@
 				},
 				"regjsgen": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
 					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 				},
 				"regjsparser": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+					"resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 					"requires": {
 						"jsesc": "~0.5.0"
@@ -3482,12 +3606,14 @@
 		"beeper": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+			"dev": true
 		},
 		"before-after-hook": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
-			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
+			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+			"dev": true
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -3507,11 +3633,12 @@
 		"bindings": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+			"integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+			"dev": true
 		},
 		"bl": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -3637,7 +3764,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -3671,7 +3798,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -3713,7 +3840,8 @@
 		"btoa-lite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"dev": true
 		},
 		"buffer": {
 			"version": "5.4.2",
@@ -3766,17 +3894,20 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+			"dev": true
 		},
 		"byline": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+			"dev": true
 		},
 		"byte-size": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
-			"integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw=="
+			"integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+			"dev": true
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -3787,6 +3918,7 @@
 			"version": "11.3.3",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
 			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.5",
 				"chownr": "^1.1.1",
@@ -3808,6 +3940,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -3815,7 +3948,8 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -3855,6 +3989,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
 			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
 			"requires": {
 				"callsites": "^2.0.0"
 			},
@@ -3862,7 +3997,8 @@
 				"callsites": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
 				}
 			}
 		},
@@ -3881,7 +4017,7 @@
 		},
 		"callsites": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
 			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
 		},
 		"camelcase": {
@@ -3893,6 +4029,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
@@ -3902,7 +4039,8 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				}
 			}
 		},
@@ -3914,7 +4052,8 @@
 		"canonical-path": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz",
-			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ="
+			"integrity": "sha1-4x65N6jJPuKgHfGDl5RyGQKHRXQ=",
+			"dev": true
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -3925,6 +4064,7 @@
 			"version": "0.8.10",
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.10.tgz",
 			"integrity": "sha512-l2OUaz/3PU3MZylspVFJvwHCVfWyvcduPq4lv3AzZ2pJzZCo7kNKFNyatwujD7XgvGkNAE/Jhhbh2uARNwNkfw==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
 			}
@@ -4010,7 +4150,8 @@
 		"ci-info": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+			"dev": true
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -4070,7 +4211,7 @@
 			"dependencies": {
 				"colors": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
 					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
 				}
 			}
@@ -4175,6 +4316,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"mkdirp": "~0.5.0"
@@ -4233,7 +4375,8 @@
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
 		},
 		"colornames": {
 			"version": "1.1.1",
@@ -4258,6 +4401,7 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+			"dev": true,
 			"requires": {
 				"strip-ansi": "^3.0.0",
 				"wcwidth": "^1.0.0"
@@ -4266,12 +4410,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4311,6 +4457,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
 				"dot-prop": "^3.0.0"
@@ -4320,6 +4467,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -4474,6 +4622,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.1.tgz",
 			"integrity": "sha512-48+FE5RJ0qc8azwKv4keVQWlni1hZeSjcWr8shBelOBtBHcKj1aJFM9lHRiSc1x7lq416pkvsqfBMhSRja+Lhw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"date-fns": "^1.23.0",
@@ -4490,6 +4639,7 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -4500,6 +4650,7 @@
 							"version": "5.5.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
 							"requires": {
 								"has-flag": "^3.0.0"
 							}
@@ -4509,17 +4660,20 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
 					"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+					"dev": true,
 					"requires": {
 						"normalize-package-data": "^2.3.2",
 						"parse-json": "^4.0.0",
@@ -4529,12 +4683,14 @@
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -4544,6 +4700,7 @@
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
 					},
@@ -4551,7 +4708,8 @@
 						"has-flag": {
 							"version": "2.0.0",
 							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-							"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+							"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+							"dev": true
 						}
 					}
 				},
@@ -4559,6 +4717,7 @@
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.2.0",
@@ -4578,6 +4737,7 @@
 					"version": "11.1.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -4589,6 +4749,7 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
 			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
@@ -4605,7 +4766,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -4626,6 +4788,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
 			"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"q": "^1.5.1"
@@ -4635,6 +4798,7 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
 			"integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
+			"dev": true,
 			"requires": {
 				"conventional-changelog-writer": "^4.0.5",
 				"conventional-commits-parser": "^3.0.2",
@@ -4655,6 +4819,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -4663,6 +4828,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -4672,6 +4838,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -4680,6 +4847,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -4687,12 +4855,14 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -4702,6 +4872,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4711,12 +4882,14 @@
 		"conventional-changelog-preset-loader": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
-			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA=="
+			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==",
+			"dev": true
 		},
 		"conventional-changelog-writer": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz",
 			"integrity": "sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==",
+			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^2.0.2",
@@ -4734,6 +4907,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4744,6 +4918,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
 			"integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
+			"dev": true,
 			"requires": {
 				"lodash.ismatch": "^4.4.0",
 				"modify-values": "^1.0.0"
@@ -4753,6 +4928,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
 			"integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
+			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^2.0.0",
@@ -4767,6 +4943,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
 					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
 					"requires": {
 						"readable-stream": "2 || 3"
 					}
@@ -4777,6 +4954,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz",
 			"integrity": "sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==",
+			"dev": true,
 			"requires": {
 				"concat-stream": "^2.0.0",
 				"conventional-changelog-preset-loader": "^2.1.1",
@@ -4792,6 +4970,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
 					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"inherits": "^2.0.3",
@@ -4872,6 +5051,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
 			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
@@ -4883,6 +5063,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.4.tgz",
 			"integrity": "sha512-eyqUWA/7RT0JagiL0tThVhjbIjoiEUyWCjtUJoOPcWoeofP5WK/jb2OJYoBFrR6DvplR+AxOyuBqk4JHkk5ykA==",
+			"dev": true,
 			"requires": {
 				"growl": "~> 1.10.0",
 				"js-yaml": "^3.11.0",
@@ -4932,7 +5113,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -4944,7 +5125,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -5045,6 +5226,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -5067,6 +5249,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -5082,7 +5265,8 @@
 		"date-fns": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+			"dev": true
 		},
 		"date-now": {
 			"version": "0.1.4",
@@ -5098,6 +5282,7 @@
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
 			"integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
+			"dev": true,
 			"requires": {
 				"bindings": "~1.2.1",
 				"node-addon-api": "^1.6.0"
@@ -5121,7 +5306,8 @@
 		"debuglog": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+			"dev": true
 		},
 		"decache": {
 			"version": "4.4.0",
@@ -5140,6 +5326,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -5148,7 +5335,8 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
 				}
 			}
 		},
@@ -5168,7 +5356,8 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+			"dev": true
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -5191,7 +5380,8 @@
 		"deepmerge": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-			"integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+			"integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "2.0.0",
@@ -5205,6 +5395,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -5262,7 +5453,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -5272,7 +5464,8 @@
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"dev": true
 		},
 		"des.js": {
 			"version": "1.0.0",
@@ -5301,17 +5494,20 @@
 		"detect-indent": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+			"dev": true
 		},
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+			"dev": true
 		},
 		"dezalgo": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
 			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+			"dev": true,
 			"requires": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
@@ -5334,7 +5530,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -5373,6 +5569,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -5380,12 +5577,14 @@
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+			"dev": true
 		},
 		"duplexer2": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "~1.1.9"
 			},
@@ -5393,12 +5592,14 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -5409,7 +5610,8 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				}
 			}
 		},
@@ -5528,7 +5730,7 @@
 		},
 		"enabled": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
 			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
 			"requires": {
 				"env-variable": "0.0.x"
@@ -5543,6 +5745,7 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -5578,7 +5781,8 @@
 		"err-code": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+			"dev": true
 		},
 		"errlop": {
 			"version": "1.1.1",
@@ -5679,12 +5883,14 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -5712,6 +5918,7 @@
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
 			"integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+			"dev": true,
 			"requires": {
 				"esprima": "^1.2.2",
 				"estraverse": "^1.9.1",
@@ -5723,22 +5930,26 @@
 				"esprima": {
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-					"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
+					"integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+					"dev": true
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
 				},
 				"fast-levenshtein": {
 					"version": "1.0.7",
 					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk="
+					"integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+					"dev": true
 				},
 				"levn": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
 					"integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+					"dev": true,
 					"requires": {
 						"prelude-ls": "~1.1.0",
 						"type-check": "~0.3.1"
@@ -5748,6 +5959,7 @@
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
 					"integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+					"dev": true,
 					"requires": {
 						"deep-is": "~0.1.2",
 						"fast-levenshtein": "~1.0.0",
@@ -5759,8 +5971,9 @@
 				},
 				"source-map": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
@@ -5769,13 +5982,14 @@
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
 				}
 			}
 		},
 		"eslint": {
 			"version": "4.19.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"requires": {
 				"ajv": "^5.3.0",
@@ -5893,7 +6107,7 @@
 		},
 		"espree": {
 			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
 				"acorn": "^5.5.0",
@@ -5947,6 +6161,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
 			"integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
 				"from": "^0.1.7",
@@ -5960,7 +6175,8 @@
 		"eventemitter3": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+			"dev": true
 		},
 		"events": {
 			"version": "3.0.0",
@@ -6034,6 +6250,7 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
 			"requires": {
 				"fill-range": "^2.1.0"
 			},
@@ -6042,6 +6259,7 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+					"dev": true,
 					"requires": {
 						"is-number": "^2.1.0",
 						"isobject": "^2.0.0",
@@ -6053,12 +6271,14 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+					"dev": true
 				},
 				"is-number": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -6067,6 +6287,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+					"dev": true,
 					"requires": {
 						"isarray": "1.0.0"
 					}
@@ -6075,6 +6296,7 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6248,6 +6470,7 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
 			"integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
+			"dev": true,
 			"requires": {
 				"ansi-gray": "^0.1.1",
 				"color-support": "^1.1.3",
@@ -6290,13 +6513,14 @@
 		},
 		"fecha": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+			"resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
 			"integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
 		},
 		"fibers": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
 			"integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
+			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3"
 			}
@@ -6326,12 +6550,14 @@
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
 		},
 		"fileset": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
 			"integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+			"dev": true,
 			"requires": {
 				"glob": "5.x",
 				"minimatch": "2.x"
@@ -6341,6 +6567,7 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -6353,6 +6580,7 @@
 					"version": "2.0.10",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.0.0"
 					}
@@ -6544,6 +6772,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
 			"requires": {
 				"for-in": "^1.0.1"
 			}
@@ -6551,7 +6780,8 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"foreground-child": {
 			"version": "1.5.6",
@@ -6622,7 +6852,8 @@
 		"from": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
 		},
 		"from2": {
 			"version": "2.3.0",
@@ -6666,6 +6897,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
 			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -6676,6 +6908,7 @@
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
 			"integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -6742,7 +6975,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -6760,11 +6994,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -6777,15 +7013,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -6888,7 +7127,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -6898,6 +7138,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -6910,17 +7151,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -6937,6 +7181,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -7009,7 +7254,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -7019,6 +7265,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -7094,7 +7341,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -7124,6 +7372,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7141,6 +7390,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7179,11 +7429,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
@@ -7201,6 +7453,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -7215,12 +7468,14 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -7229,6 +7484,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -7239,6 +7495,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -7248,7 +7505,8 @@
 		"genfun": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
-			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
+			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -7264,6 +7522,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"meow": "^3.3.0",
@@ -7275,12 +7534,14 @@
 				"camelcase": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
 				},
 				"camelcase-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^2.0.0",
 						"map-obj": "^1.0.0"
@@ -7290,6 +7551,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -7299,6 +7561,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"dev": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
@@ -7307,6 +7570,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -7318,12 +7582,14 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
 				},
 				"meow": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+					"dev": true,
 					"requires": {
 						"camelcase-keys": "^2.0.0",
 						"decamelize": "^1.1.2",
@@ -7341,6 +7607,7 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -7349,6 +7616,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -7357,6 +7625,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -7366,12 +7635,14 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -7382,6 +7653,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -7391,6 +7663,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+					"dev": true,
 					"requires": {
 						"indent-string": "^2.1.0",
 						"strip-indent": "^1.0.1"
@@ -7400,6 +7673,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -7408,6 +7682,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"dev": true,
 					"requires": {
 						"get-stdin": "^4.0.1"
 					}
@@ -7415,14 +7690,16 @@
 				"trim-newlines": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+					"dev": true
 				}
 			}
 		},
 		"get-port": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"dev": true
 		},
 		"get-stdin": {
 			"version": "4.0.1",
@@ -7468,6 +7745,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
 			"integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+			"dev": true,
 			"requires": {
 				"dargs": "^4.0.1",
 				"lodash.template": "^4.0.2",
@@ -7480,6 +7758,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"dev": true,
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
 				"pify": "^2.3.0"
@@ -7488,7 +7767,8 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				}
 			}
 		},
@@ -7496,6 +7776,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
 			"integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+			"dev": true,
 			"requires": {
 				"meow": "^4.0.0",
 				"semver": "^5.5.0"
@@ -7504,7 +7785,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -7512,6 +7794,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
 			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"parse-url": "^5.0.0"
@@ -7521,6 +7804,7 @@
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
 			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+			"dev": true,
 			"requires": {
 				"git-up": "^4.0.0"
 			}
@@ -7529,6 +7813,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.2"
 			}
@@ -7558,6 +7843,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
 			"requires": {
 				"glob-parent": "^2.0.0",
 				"is-glob": "^2.0.0"
@@ -7567,6 +7853,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
 					"requires": {
 						"is-glob": "^2.0.0"
 					}
@@ -7574,12 +7861,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7609,6 +7898,7 @@
 			"version": "5.3.5",
 			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
 				"glob": "^5.0.3",
@@ -7624,6 +7914,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+					"dev": true,
 					"requires": {
 						"arr-flatten": "^1.0.1"
 					}
@@ -7631,12 +7922,14 @@
 				"array-unique": {
 					"version": "0.2.1",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+					"dev": true
 				},
 				"braces": {
 					"version": "1.8.5",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+					"dev": true,
 					"requires": {
 						"expand-range": "^1.8.1",
 						"preserve": "^0.2.0",
@@ -7647,6 +7940,7 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+					"dev": true,
 					"requires": {
 						"is-posix-bracket": "^0.1.0"
 					}
@@ -7655,6 +7949,7 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7663,6 +7958,7 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -7674,17 +7970,20 @@
 				"is-buffer": {
 					"version": "1.1.6",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+					"dev": true
 				},
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -7692,12 +7991,14 @@
 				"isarray": {
 					"version": "0.0.1",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -7706,6 +8007,7 @@
 					"version": "2.3.11",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+					"dev": true,
 					"requires": {
 						"arr-diff": "^2.0.0",
 						"array-unique": "^0.2.1",
@@ -7726,6 +8028,7 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
 					"requires": {
 						"remove-trailing-separator": "^1.0.1"
 					}
@@ -7734,6 +8037,7 @@
 					"version": "1.0.34",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.1",
@@ -7744,12 +8048,14 @@
 				"string_decoder": {
 					"version": "0.10.31",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
 				},
 				"through2": {
 					"version": "0.6.5",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+					"dev": true,
 					"requires": {
 						"readable-stream": ">=1.0.33-1 <1.1.0-0",
 						"xtend": ">=4.0.0 <4.1.0-0"
@@ -7829,6 +8135,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
 			"integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
+			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
@@ -7883,6 +8190,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/gulp-license-check/-/gulp-license-check-1.2.1.tgz",
 			"integrity": "sha1-EPJLmGlj9RNmQRw3hN8lkOZARAg=",
+			"dev": true,
 			"requires": {
 				"event-stream": "^3.3.2",
 				"gulp-util": "^3.0.7",
@@ -7894,6 +8202,7 @@
 					"version": "3.3.5",
 					"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
 					"integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+					"dev": true,
 					"requires": {
 						"duplexer": "^0.1.1",
 						"from": "^0.1.7",
@@ -7910,6 +8219,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"dev": true,
 			"requires": {
 				"convert-source-map": "^1.1.1",
 				"graceful-fs": "^4.1.2",
@@ -7922,6 +8232,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -7930,6 +8241,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -7942,6 +8254,7 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
 			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"dev": true,
 			"requires": {
 				"array-differ": "^1.0.0",
 				"array-uniq": "^1.0.2",
@@ -7966,17 +8279,20 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -7988,12 +8304,14 @@
 				"dateformat": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+					"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+					"dev": true
 				},
 				"lodash.template": {
 					"version": "3.6.2",
 					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
 					"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+					"dev": true,
 					"requires": {
 						"lodash._basecopy": "^3.0.0",
 						"lodash._basetostring": "^3.0.0",
@@ -8010,6 +8328,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
 					"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+					"dev": true,
 					"requires": {
 						"lodash._reinterpolate": "^3.0.0",
 						"lodash.escape": "^3.0.0"
@@ -8018,12 +8337,14 @@
 				"object-assign": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -8031,7 +8352,8 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -8039,6 +8361,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
 			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"dev": true,
 			"requires": {
 				"glogg": "^1.0.0"
 			}
@@ -8107,6 +8430,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
 			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"dev": true,
 			"requires": {
 				"sparkles": "^1.0.0"
 			}
@@ -8132,7 +8456,8 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -8225,11 +8550,12 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -8254,6 +8580,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -8263,6 +8590,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -8288,6 +8616,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
 			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"dev": true,
 			"requires": {
 				"agent-base": "^4.1.0",
 				"debug": "^3.1.0"
@@ -8297,6 +8626,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -8304,7 +8634,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -8312,6 +8643,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -8358,6 +8690,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
@@ -8371,6 +8704,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
 			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"dev": true,
 			"requires": {
 				"caller-path": "^2.0.0",
 				"resolve-from": "^3.0.0"
@@ -8380,6 +8714,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
 					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+					"dev": true,
 					"requires": {
 						"caller-callsite": "^2.0.0"
 					}
@@ -8387,7 +8722,8 @@
 				"resolve-from": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
 				}
 			}
 		},
@@ -8395,6 +8731,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
 			"requires": {
 				"pkg-dir": "^2.0.0",
 				"resolve-cwd": "^2.0.0"
@@ -8404,6 +8741,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -8412,6 +8750,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -8421,6 +8760,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -8429,6 +8769,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -8436,12 +8777,14 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				},
 				"pkg-dir": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.1.0"
 					}
@@ -8486,6 +8829,7 @@
 			"version": "1.10.3",
 			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
 			"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
 				"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -8500,7 +8844,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -8557,7 +8902,8 @@
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -8614,6 +8960,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
 			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"dev": true,
 			"requires": {
 				"ci-info": "^1.5.0"
 			}
@@ -8666,17 +9013,20 @@
 		"is-directory": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
 			"requires": {
 				"is-primitive": "^2.0.0"
 			}
@@ -8695,6 +9045,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -8743,7 +9094,8 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -8766,12 +9118,14 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
 		},
 		"is-promise": {
 			"version": "2.1.0",
@@ -8808,6 +9162,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
 			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+			"dev": true,
 			"requires": {
 				"protocols": "^1.1.0"
 			}
@@ -8829,6 +9184,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
 			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+			"dev": true,
 			"requires": {
 				"text-extensions": "^2.0.0"
 			}
@@ -8846,7 +9202,8 @@
 		"is-valid-glob": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -8890,6 +9247,7 @@
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
 			"integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
+			"dev": true,
 			"requires": {
 				"abbrev": "1.0.x",
 				"async": "1.x",
@@ -8909,28 +9267,33 @@
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"esprima": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
-					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw="
+					"integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
+					"dev": true
 				},
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -8941,6 +9304,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/istanbul-combine/-/istanbul-combine-0.3.0.tgz",
 			"integrity": "sha1-VrLV5joiBZi23ErIrVcucV6ZV3M=",
+			"dev": true,
 			"requires": {
 				"glob": "^5.0.3",
 				"istanbul": "0.3.x",
@@ -8952,6 +9316,7 @@
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -9045,6 +9410,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/istanbul-merge/-/istanbul-merge-1.1.1.tgz",
 			"integrity": "sha1-db5kNDbU3nI+A6lNHKX1+ZSwvXI=",
+			"dev": true,
 			"requires": {
 				"foreach": "^2.0.5",
 				"glob": "^7.0.5",
@@ -9056,17 +9422,20 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
 				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+					"dev": true
 				},
 				"cliui": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1",
@@ -9077,6 +9446,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -9085,17 +9455,20 @@
 				"get-caller-file": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+					"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -9103,12 +9476,14 @@
 				"istanbul-lib-coverage": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
@@ -9117,6 +9492,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -9129,6 +9505,7 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
 					}
@@ -9137,6 +9514,7 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -9145,6 +9523,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -9153,6 +9532,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -9162,12 +9542,14 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -9178,6 +9560,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -9186,12 +9569,14 @@
 				"require-main-filename": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -9202,6 +9587,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -9210,6 +9596,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -9217,17 +9604,20 @@
 				"which-module": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+					"dev": true
 				},
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"dev": true
 				},
 				"yargs": {
 					"version": "4.8.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
 						"decamelize": "^1.1.1",
@@ -9249,6 +9639,7 @@
 					"version": "2.4.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
 					"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+					"dev": true,
 					"requires": {
 						"camelcase": "^3.0.0",
 						"lodash.assign": "^4.0.6"
@@ -9306,6 +9697,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
 			"integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
+			"dev": true,
 			"requires": {
 				"xmlcreate": "^2.0.0"
 			}
@@ -9319,6 +9711,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.2.tgz",
 			"integrity": "sha512-S2vzg99C5+gb7FWlrK4TVdyzVPGGkdvpDkCEJH1JABi2PKzPeLu5/zZffcJUifgWUJqXWl41Hoc+MmuM2GukIg==",
+			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.4.4",
 				"bluebird": "^3.5.4",
@@ -9339,12 +9732,14 @@
 				"escape-string-regexp": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
 				}
 			}
 		},
@@ -9352,6 +9747,7 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/jsdoc-sphinx/-/jsdoc-sphinx-0.0.6.tgz",
 			"integrity": "sha1-7rerF8QgLEYqBcWwmlb3cQiXvzE=",
+			"dev": true,
 			"requires": {
 				"async": "^1.5.0",
 				"canonical-path": "0.0.2",
@@ -9365,12 +9761,14 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"lodash": {
 					"version": "3.10.1",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+					"dev": true
 				}
 			}
 		},
@@ -9595,6 +9993,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -9607,7 +10006,8 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -9676,6 +10076,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.9"
 			}
@@ -9739,12 +10140,14 @@
 		"lcov-parse": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
+			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"dev": true
 		},
 		"lerna": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.15.0.tgz",
 			"integrity": "sha512-kRIQ3bgzkmew5/WZQ0C9WjH0IUf3ZmTNnBwTHfXgLkVY7td0lbwMQFD7zehflUn0zG4ou54o/gn+IfjF0ti/5A==",
+			"dev": true,
 			"requires": {
 				"@lerna/add": "3.15.0",
 				"@lerna/bootstrap": "3.15.0",
@@ -9778,6 +10181,7 @@
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/license-check/-/license-check-1.1.5.tgz",
 			"integrity": "sha1-oAuYVtXMfzSwFx5OTJDi8GZTLXY=",
+			"dev": true,
 			"requires": {
 				"gulp-license-check": "^1.1.2",
 				"gulp-util": "^3.0.7",
@@ -9788,13 +10192,15 @@
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
 				},
 				"escodegen": {
 					"version": "1.8.1",
 					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 					"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+					"dev": true,
 					"requires": {
 						"esprima": "^2.7.1",
 						"estraverse": "^1.9.1",
@@ -9806,17 +10212,20 @@
 				"esprima": {
 					"version": "2.7.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
 				},
 				"estraverse": {
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
 				},
 				"glob": {
 					"version": "5.0.15",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
 					"requires": {
 						"inflight": "^1.0.4",
 						"inherits": "2",
@@ -9828,12 +10237,14 @@
 				"has-flag": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
 				},
 				"istanbul": {
 					"version": "0.4.5",
 					"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
 					"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+					"dev": true,
 					"requires": {
 						"abbrev": "1.0.x",
 						"async": "1.x",
@@ -9854,12 +10265,14 @@
 				"resolve": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
 					"optional": true,
 					"requires": {
 						"amdefine": ">=0.0.4"
@@ -9869,6 +10282,7 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
 					"requires": {
 						"has-flag": "^1.0.0"
 					}
@@ -9879,6 +10293,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/license-check-and-add/-/license-check-and-add-2.3.6.tgz",
 			"integrity": "sha512-fTSOoJL12YhsTOS+xqutJ7uwIcN4kPcmhCk39FWTjc1Zllyc62JGT1i+NqTfyTh38wzLQDzfLDjqsI4jSzMnfg==",
+			"dev": true,
 			"requires": {
 				"pkg-conf": "^1.1.2"
 			}
@@ -9887,6 +10302,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/licensecheck/-/licensecheck-1.3.0.tgz",
 			"integrity": "sha1-ouuJ7fqZ0ndBZ1LWp9Mp+p+wz9Q=",
+			"dev": true,
 			"requires": {
 				"colors": "1.1.2",
 				"markdown": "0.5.0",
@@ -9898,7 +10314,8 @@
 				"colors": {
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+					"dev": true
 				}
 			}
 		},
@@ -9914,6 +10331,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
 			"integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+			"dev": true,
 			"requires": {
 				"uc.micro": "^1.0.1"
 			}
@@ -9978,57 +10396,68 @@
 		"lodash._basecopy": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
 		},
 		"lodash._basetostring": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+			"dev": true
 		},
 		"lodash._basevalues": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+			"dev": true
 		},
 		"lodash._getnative": {
 			"version": "3.9.1",
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
 		},
 		"lodash._isiterateecall": {
 			"version": "3.0.9",
 			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
 		},
 		"lodash._reescape": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+			"dev": true
 		},
 		"lodash._reevaluate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+			"dev": true
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
 		},
 		"lodash._root": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+			"dev": true
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
@@ -10044,6 +10473,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
 			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"dev": true,
 			"requires": {
 				"lodash._root": "^3.0.0"
 			}
@@ -10066,22 +10496,26 @@
 		"lodash.isarguments": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
 		},
 		"lodash.isarray": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+			"dev": true
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -10092,6 +10526,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
 			"requires": {
 				"lodash._getnative": "^3.0.0",
 				"lodash.isarguments": "^3.0.0",
@@ -10106,22 +10541,26 @@
 		"lodash.restparam": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"lodash.template": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
 			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0",
 				"lodash.templatesettings": "^4.0.0"
@@ -10131,6 +10570,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
 			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"dev": true,
 			"requires": {
 				"lodash._reinterpolate": "~3.0.0"
 			}
@@ -10143,12 +10583,14 @@
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
 		},
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -10202,6 +10644,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
@@ -10229,7 +10672,8 @@
 		"macos-release": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
+			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+			"dev": true
 		},
 		"make-dir": {
 			"version": "2.1.0",
@@ -10251,6 +10695,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.2.tgz",
 			"integrity": "sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==",
+			"dev": true,
 			"requires": {
 				"agentkeepalive": "^3.4.1",
 				"cacache": "^11.3.3",
@@ -10269,6 +10714,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -10276,7 +10722,8 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -10301,12 +10748,14 @@
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+			"dev": true
 		},
 		"map-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+			"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -10320,6 +10769,7 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
 			"integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
+			"dev": true,
 			"requires": {
 				"nopt": "~2.1.1"
 			},
@@ -10328,6 +10778,7 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
 					"integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+					"dev": true,
 					"requires": {
 						"abbrev": "1"
 					}
@@ -10338,6 +10789,7 @@
 			"version": "8.4.2",
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
 			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"entities": "~1.1.1",
@@ -10349,17 +10801,20 @@
 		"markdown-it-anchor": {
 			"version": "5.2.4",
 			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
-			"integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A=="
+			"integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
+			"dev": true
 		},
 		"marked": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-			"integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
+			"integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
+			"dev": true
 		},
 		"math-random": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -10378,7 +10833,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -10498,6 +10953,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
 			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+			"dev": true,
 			"requires": {
 				"camelcase-keys": "^4.0.0",
 				"decamelize-keys": "^1.0.0",
@@ -10514,6 +10970,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -10522,6 +10979,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -10531,6 +10989,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -10539,6 +10998,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -10546,12 +11006,14 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				},
 				"read-pkg-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
 					"requires": {
 						"find-up": "^2.0.0",
 						"read-pkg": "^3.0.0"
@@ -10583,6 +11045,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.1"
 			},
@@ -10591,6 +11054,7 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -10605,6 +11069,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -10698,13 +11163,14 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -10714,6 +11180,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -10722,7 +11189,8 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -10730,6 +11198,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+			"dev": true,
 			"requires": {
 				"minipass": "^2.2.1"
 			}
@@ -10780,7 +11249,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
@@ -10891,7 +11360,8 @@
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw=="
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+			"dev": true
 		},
 		"moment-mini": {
 			"version": "2.22.1",
@@ -10936,6 +11406,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
 			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"dev": true,
 			"requires": {
 				"duplexer2": "0.0.2"
 			}
@@ -10943,7 +11414,8 @@
 		"mustache": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
-			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
+			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+			"dev": true
 		},
 		"mute-stream": {
 			"version": "0.0.7",
@@ -11086,7 +11558,8 @@
 		"node-addon-api": {
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
-			"integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+			"integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg==",
+			"dev": true
 		},
 		"node-cache": {
 			"version": "4.2.0",
@@ -11123,12 +11596,14 @@
 		"node-fetch": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+			"dev": true
 		},
 		"node-fetch-npm": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
 			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"json-parse-better-errors": "^1.0.0",
@@ -11139,6 +11614,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
 			"integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.3",
 				"graceful-fs": "^4.1.2",
@@ -11156,7 +11632,8 @@
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true
 				}
 			}
 		},
@@ -11255,6 +11732,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
 			"requires": {
 				"abbrev": "1"
 			}
@@ -11285,17 +11763,20 @@
 		"normalize-url": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
 		},
 		"npm-bundled": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+			"dev": true
 		},
 		"npm-lifecycle": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.1.tgz",
 			"integrity": "sha512-+Vg6I60Z75V/09pdcH5iUo/99Q/vop35PaI99elvxk56azSVVsdsSsS/sXqKDNwbRRNN1qSxkcO45ZOu0yOWew==",
+			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
 				"graceful-fs": "^4.1.15",
@@ -11310,7 +11791,8 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
 				}
 			}
 		},
@@ -11318,6 +11800,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
 			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.6.0",
 				"osenv": "^0.1.5",
@@ -11328,7 +11811,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -11336,6 +11820,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
 			"integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+			"dev": true,
 			"requires": {
 				"ignore-walk": "^3.0.1",
 				"npm-bundled": "^1.0.1"
@@ -11345,6 +11830,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
 			"integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
@@ -11354,7 +11840,8 @@
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -11370,6 +11857,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -11436,7 +11924,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "^1.0.0"
@@ -11472,7 +11960,7 @@
 				},
 				"yargs": {
 					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
 					"requires": {
 						"camelcase": "^2.0.1",
@@ -11655,6 +12143,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
 			"requires": {
 				"for-own": "^0.1.4",
 				"is-extendable": "^0.1.1"
@@ -11671,7 +12160,8 @@
 		"octokit-pagination-methods": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
+			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+			"dev": true
 		},
 		"on-finished": {
 			"version": "2.3.0",
@@ -11720,7 +12210,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
 					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
 				},
 				"wordwrap": {
@@ -11747,6 +12237,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"dev": true,
 			"requires": {
 				"is-stream": "^1.0.1",
 				"readable-stream": "^2.0.1"
@@ -11756,6 +12247,7 @@
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -11770,6 +12262,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -11800,6 +12293,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
 			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+			"dev": true,
 			"requires": {
 				"macos-release": "^2.2.0",
 				"windows-release": "^3.1.0"
@@ -11814,6 +12308,7 @@
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -11868,12 +12363,14 @@
 		"p-map": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
 		},
 		"p-map-series": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
 			"integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -11881,12 +12378,14 @@
 		"p-pipe": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
-			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k="
+			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+			"dev": true
 		},
 		"p-queue": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-queue/-/p-queue-4.0.0.tgz",
 			"integrity": "sha512-3cRXXn3/O0o3+eVmUroJPSj/esxoEFIm0ZOno/T+NzG/VZgPOqQ8WKmlNqubSEpZmCIngEy34unkHGg83ZIBmg==",
+			"dev": true,
 			"requires": {
 				"eventemitter3": "^3.1.0"
 			}
@@ -11894,7 +12393,8 @@
 		"p-reduce": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
 		},
 		"p-timeout": {
 			"version": "1.2.1",
@@ -11913,6 +12413,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-1.0.0.tgz",
 			"integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
+			"dev": true,
 			"requires": {
 				"p-reduce": "^1.0.0"
 			}
@@ -11996,12 +12497,14 @@
 		"parse-github-repo-url": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
 			"requires": {
 				"glob-base": "^0.3.0",
 				"is-dotfile": "^1.0.0",
@@ -12012,12 +12515,14 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -12036,7 +12541,8 @@
 		"parse-node-version": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
+			"integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+			"dev": true
 		},
 		"parse-passwd": {
 			"version": "1.0.0",
@@ -12047,6 +12553,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
 			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"protocols": "^1.4.0"
@@ -12056,6 +12563,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
 			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+			"dev": true,
 			"requires": {
 				"is-ssh": "^1.3.0",
 				"normalize-url": "^3.3.0",
@@ -12137,6 +12645,7 @@
 			"version": "0.0.11",
 			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
 			"requires": {
 				"through": "~2.3"
 			}
@@ -12188,6 +12697,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
 			"integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+			"dev": true,
 			"requires": {
 				"find-up": "^1.0.0",
 				"load-json-file": "^1.1.0",
@@ -12199,6 +12709,7 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
 					"requires": {
 						"path-exists": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
@@ -12208,6 +12719,7 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -12220,6 +12732,7 @@
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
@@ -12228,6 +12741,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
@@ -12235,12 +12749,14 @@
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
 				},
 				"strip-bom": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -12278,7 +12794,8 @@
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
 		},
 		"pretty-bytes": {
 			"version": "5.3.0",
@@ -12314,6 +12831,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+			"dev": true,
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
@@ -12323,6 +12841,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
 			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+			"dev": true,
 			"requires": {
 				"read": "1"
 			}
@@ -12330,17 +12849,20 @@
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
 		},
 		"protocols": {
 			"version": "1.4.7",
 			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+			"dev": true
 		},
 		"protoduck": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
 			"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+			"dev": true,
 			"requires": {
 				"genfun": "^5.0.0"
 			}
@@ -12420,7 +12942,8 @@
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -12440,7 +12963,8 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"dev": true
 		},
 		"railroad-diagrams": {
 			"version": "1.0.0",
@@ -12460,6 +12984,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+			"dev": true,
 			"requires": {
 				"is-number": "^4.0.0",
 				"kind-of": "^6.0.0",
@@ -12469,7 +12994,8 @@
 				"is-number": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
 				}
 			}
 		},
@@ -12552,6 +13078,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
 			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"dev": true,
 			"requires": {
 				"mute-stream": "~0.0.4"
 			}
@@ -12569,6 +13096,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2"
 			}
@@ -12577,6 +13105,7 @@
 			"version": "2.0.13",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
 			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.1.2",
@@ -12588,7 +13117,8 @@
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -12596,6 +13126,7 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
 			"integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+			"dev": true,
 			"requires": {
 				"read-package-json": "^2.0.0",
 				"readdir-scoped-modules": "^1.0.0",
@@ -12635,6 +13166,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
 			"integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+			"dev": true,
 			"requires": {
 				"debuglog": "^1.0.1",
 				"dezalgo": "^1.0.0",
@@ -12688,6 +13220,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"dev": true,
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
@@ -12723,6 +13256,7 @@
 			"version": "0.4.4",
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
 			}
@@ -12743,7 +13277,7 @@
 		},
 		"regexpp": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
 			"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw=="
 		},
 		"regexpu-core": {
@@ -12774,7 +13308,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -12806,6 +13340,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
 			"requires": {
 				"is-finite": "^1.0.0"
 			}
@@ -12872,7 +13407,7 @@
 		},
 		"require-uncached": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"requires": {
 				"caller-path": "^0.1.0",
@@ -12883,6 +13418,7 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.2.tgz",
 			"integrity": "sha512-oJ6y7JcUJkblRGhMByGNcszeLgU0qDxNKFCiUZR1XyzHyVsev+Mxb1tyygxLd1ORsKee1SA5BInFdUwY64GE/A==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
 			}
@@ -12958,7 +13494,8 @@
 		"retry": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -13021,7 +13558,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -13178,7 +13715,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -13266,7 +13803,8 @@
 		"sleep-promise": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
-			"integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
+			"integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U=",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "1.0.0",
@@ -13279,12 +13817,14 @@
 		"slide": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
 		},
 		"smart-buffer": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -13400,6 +13940,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
 			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+			"dev": true,
 			"requires": {
 				"ip": "^1.1.5",
 				"smart-buffer": "4.0.2"
@@ -13409,6 +13950,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
 			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "~4.2.1",
 				"socks": "~2.3.2"
@@ -13418,6 +13960,7 @@
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
 					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
 					}
@@ -13428,6 +13971,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
 			}
@@ -13478,12 +14022,14 @@
 		"sparkles": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==",
+			"dev": true
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
 			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
+			"integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+			"dev": true
 		},
 		"spawn-wrap": {
 			"version": "1.4.3",
@@ -13529,12 +14075,14 @@
 		"spdx-license-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz",
-			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0="
+			"integrity": "sha1-N4j/tcgLJK++goOTTp5mhOpqIY0=",
+			"dev": true
 		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
 			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
 			"requires": {
 				"through": "2"
 			}
@@ -13551,6 +14099,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
 			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+			"dev": true,
 			"requires": {
 				"through2": "^2.0.2"
 			}
@@ -13692,6 +14241,7 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
 			"integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+			"dev": true,
 			"requires": {
 				"duplexer": "~0.1.1",
 				"through": "~2.3.4"
@@ -13835,7 +14385,8 @@
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -13846,6 +14397,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
 			"integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
+			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
 				"minimist": "^1.2.0",
@@ -13926,12 +14478,14 @@
 		"symbol": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
-			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c="
+			"integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+			"dev": true
 		},
 		"sync": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/sync/-/sync-0.2.5.tgz",
 			"integrity": "sha1-ORC7m2ar7lZULi5w8M5UkDElLfY=",
+			"dev": true,
 			"requires": {
 				"fibers": ">=0.6"
 			}
@@ -13984,7 +14538,8 @@
 		"taffydb": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
+			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+			"dev": true
 		},
 		"taketalk": {
 			"version": "1.0.0",
@@ -14004,6 +14559,7 @@
 			"version": "4.4.10",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
 			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
@@ -14017,7 +14573,8 @@
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true
 				}
 			}
 		},
@@ -14062,12 +14619,14 @@
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"dev": true
 		},
 		"temp-write": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"is-stream": "^1.1.0",
@@ -14081,6 +14640,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -14088,7 +14648,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -14195,13 +14756,14 @@
 		},
 		"text-encoding": {
 			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
 		"text-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
-			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ=="
+			"integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+			"dev": true
 		},
 		"text-hex": {
 			"version": "1.0.0",
@@ -14276,6 +14838,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
 				"xtend": "~4.0.0"
@@ -14284,7 +14847,8 @@
 		"time-stamp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+			"dev": true
 		},
 		"timed-out": {
 			"version": "4.0.1",
@@ -14329,6 +14893,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1"
 			},
@@ -14337,6 +14902,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -14421,6 +14987,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -14428,22 +14995,26 @@
 		"tree-kill": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
+			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+			"dev": true
 		},
 		"treeify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/treeify/-/treeify-1.0.1.tgz",
-			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8="
+			"integrity": "sha1-abPNAiAioWhCTnz6HO1EyTnT6y8=",
+			"dev": true
 		},
 		"trim-newlines": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+			"dev": true
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
@@ -14526,7 +15097,8 @@
 		"uc.micro": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+			"dev": true
 		},
 		"uglify-js": {
 			"version": "3.6.0",
@@ -14549,17 +15121,20 @@
 		"uid-number": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
+			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+			"dev": true
 		},
 		"umask": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
+			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+			"dev": true
 		},
 		"underscore": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+			"dev": true
 		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
@@ -14616,6 +15191,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
 			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
+			"dev": true,
 			"requires": {
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"through2-filter": "^3.0.0"
@@ -14625,6 +15201,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
 					"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
+					"dev": true,
 					"requires": {
 						"through2": "~2.0.0",
 						"xtend": "~4.0.0"
@@ -14636,6 +15213,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
 			"integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+			"dev": true,
 			"requires": {
 				"os-name": "^3.0.0"
 			}
@@ -14643,7 +15221,8 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -14746,7 +15325,8 @@
 		"url-template": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+			"dev": true
 		},
 		"url-to-options": {
 			"version": "1.0.1",
@@ -14787,6 +15367,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
 			"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+			"dev": true,
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
@@ -14809,7 +15390,8 @@
 		"vali-date": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+			"dev": true
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
@@ -14824,6 +15406,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
 			}
@@ -14847,6 +15430,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
 			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
@@ -14895,6 +15479,7 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"dev": true,
 			"requires": {
 				"duplexify": "^3.2.0",
 				"glob-stream": "^5.3.2",
@@ -14918,12 +15503,14 @@
 				"first-chunk-stream": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+					"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+					"dev": true
 				},
 				"readable-stream": {
 					"version": "2.3.6",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -14938,6 +15525,7 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -14946,6 +15534,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
@@ -14954,6 +15543,7 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
 					"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+					"dev": true,
 					"requires": {
 						"first-chunk-stream": "^1.0.0",
 						"strip-bom": "^2.0.0"
@@ -14963,6 +15553,7 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+					"dev": true,
 					"requires": {
 						"clone": "^1.0.0",
 						"clone-stats": "^0.0.1",
@@ -14995,6 +15586,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
@@ -15002,7 +15594,8 @@
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
 		},
 		"webpack": {
 			"version": "4.39.3",
@@ -15204,6 +15797,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
 			"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+			"dev": true,
 			"requires": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
@@ -15245,12 +15839,14 @@
 		"window-size": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+			"dev": true
 		},
 		"windows-release": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
 			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
 			}
@@ -15396,6 +15992,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"dev": true,
 			"requires": {
 				"detect-indent": "^5.0.0",
 				"graceful-fs": "^4.1.2",
@@ -15409,6 +16006,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -15416,7 +16014,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -15424,6 +16023,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
 			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
+			"dev": true,
 			"requires": {
 				"sort-keys": "^2.0.0",
 				"write-json-file": "^2.2.0"
@@ -15432,7 +16032,8 @@
 		"xmlcreate": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.1.tgz",
-			"integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA=="
+			"integrity": "sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==",
+			"dev": true
 		},
 		"xregexp": {
 			"version": "4.2.4",
@@ -16124,7 +16725,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "exact_paths": [
       ".git",
       ".github",
+      ".gitattributes",
       "node_modules",
       "packages",
       "softhsm",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "exact_paths": [
       ".git",
       ".github",
-      ".gitattributes",
       "node_modules",
       "packages",
       "softhsm",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bootstrap": "lerna bootstrap",
     "pretest": "npm run doc && npm run licchk",
     "test": "lerna exec -- npm run test:cov",
+    "test:cli": "lerna exec --scope @accordproject/cicero-cli -- npm run test:cov",
     "publish": "./scripts/manualrelease.sh",
     "repoclean": "lerna clean",
     "licchk": "license-check-and-add",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bootstrap": "lerna bootstrap",
     "pretest": "npm run doc && npm run licchk",
     "test": "lerna exec -- npm run test:cov",
-    "test:cli": "lerna exec --scope @accordproject/cicero-cli -- npm run test:cov",
+    "test:cli": "lerna exec --scope @accordproject/cicero-cli -- npm run test:mocha",
     "publish": "./scripts/manualrelease.sh",
     "repoclean": "lerna clean",
     "licchk": "license-check-and-add",

--- a/packages/cicero-cli/.eslintrc.yml
+++ b/packages/cicero-cli/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/cicero-cli/package.json
+++ b/packages/cicero-cli/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check",
-    "test:cucumber": "cucumber-js test/features --require .cucumber.js --world-parameters '{\"rootdir\":\"./test\"}'",
+    "test:cucumber": "cucumber-js test/features --require .cucumber.js --world-parameters \"{\\\"rootdir\\\":\\\"./test\\\"}\"",
     "test:mocha": "mocha",
     "test:all": "npm run test:mocha && npm run test:cucumber",
     "test:cov": "nyc npm run test",

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -145,7 +145,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateParseArgs({
                 _: ['parse'],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified', () => {
@@ -155,7 +155,7 @@ describe('cicero-cli', () => {
                 template: './',
                 sample: 'sample.txt'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder', () => {
@@ -165,7 +165,7 @@ describe('cicero-cli', () => {
                 template: 'latedeliveryandpenalty',
                 sample: 'latedeliveryandpenalty/sample.txt'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, archive', () => {
@@ -175,7 +175,7 @@ describe('cicero-cli', () => {
                 template: 'latedeliveryandpenalty.cta',
                 sample: 'latedeliveryandpenalty/sample.txt'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty.cta$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty.cta$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder, no sample', () => {
@@ -184,7 +184,7 @@ describe('cicero-cli', () => {
                 _: ['parse'],
                 template: 'latedeliveryandpenalty',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, child folder, no sample', () => {
@@ -193,14 +193,14 @@ describe('cicero-cli', () => {
                 _: ['parse'],
                 template: '../',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('no flags specified', () => {
             const args  = Commands.validateParseArgs({
                 _: ['parse', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('verbose flag specified', () => {
@@ -231,7 +231,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateGenerateTextArgs({
                 _: ['generateText'],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('all args specified', () => {
@@ -241,7 +241,7 @@ describe('cicero-cli', () => {
                 template: './',
                 data: 'data.json'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('all args specified, parent folder', () => {
@@ -251,7 +251,7 @@ describe('cicero-cli', () => {
                 template: 'latedeliveryandpenalty',
                 data: 'latedeliveryandpenalty/data.json'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('all args specified, archive', () => {
@@ -261,7 +261,7 @@ describe('cicero-cli', () => {
                 template: 'latedeliveryandpenalty.cta',
                 data: 'latedeliveryandpenalty/data.json'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty.cta$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty.cta$/);
             args.data.should.match(/data.json$/);
         });
         it('all args specified, parent folder, no sample', () => {
@@ -270,7 +270,7 @@ describe('cicero-cli', () => {
                 _: ['generateText'],
                 template: 'latedeliveryandpenalty',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('all args specified, child folder, no sample', () => {
@@ -279,14 +279,14 @@ describe('cicero-cli', () => {
                 _: ['generateText'],
                 template: '../',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('no flags specified', () => {
             const args  = Commands.validateGenerateTextArgs({
                 _: ['generateText', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.data.should.match(/data.json$/);
         });
         it('verbose flag specified', () => {
@@ -396,7 +396,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateInitArgs({
                 _: ['init'],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified', () => {
@@ -406,7 +406,7 @@ describe('cicero-cli', () => {
                 template: './',
                 sample: 'sample.txt'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder', () => {
@@ -416,7 +416,7 @@ describe('cicero-cli', () => {
                 template: 'latedeliveryandpenalty',
                 sample: 'latedeliveryandpenalty/sample.txt'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder, no sample, no state', () => {
@@ -425,7 +425,7 @@ describe('cicero-cli', () => {
                 _: ['init'],
                 template: 'latedeliveryandpenalty',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, child folder, no sample', () => {
@@ -434,14 +434,14 @@ describe('cicero-cli', () => {
                 _: ['init'],
                 template: '../',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('no flags specified', () => {
             const args  = Commands.validateInitArgs({
                 _: ['init', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('verbose flag specified', () => {
@@ -472,7 +472,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateExecuteArgs({
                 _: ['execute'],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified', () => {
@@ -483,7 +483,7 @@ describe('cicero-cli', () => {
                 sample: 'sample.txt',
                 state: 'state.json'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder', () => {
@@ -494,7 +494,7 @@ describe('cicero-cli', () => {
                 sample: 'latedeliveryandpenalty/sample.txt',
                 state: 'latedeliveryandpenalty/state.json'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, parent folder, no sample, no state', () => {
@@ -503,7 +503,7 @@ describe('cicero-cli', () => {
                 _: ['execute'],
                 template: 'latedeliveryandpenalty',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('all args specified, child folder, no sample', () => {
@@ -512,14 +512,14 @@ describe('cicero-cli', () => {
                 _: ['execute'],
                 template: '../',
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('no flags specified', () => {
             const args  = Commands.validateExecuteArgs({
                 _: ['execute', path.resolve(__dirname, 'data/latedeliveryandpenalty/')],
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.sample.should.match(/sample.txt$/);
         });
         it('verbose flag specified', () => {
@@ -624,7 +624,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateArchiveArgs({
                 _: ['archive']
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.target.should.match(/ergo/);
         });
         it('only target arg specified', () => {
@@ -633,7 +633,7 @@ describe('cicero-cli', () => {
                 _: ['archive'],
                 target: 'ergo'
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.target.should.match(/ergo/);
         });
         it('template arg specified', () => {
@@ -641,7 +641,7 @@ describe('cicero-cli', () => {
             const args  = Commands.validateArchiveArgs({
                 _: ['archive', 'data/latedeliveryandpenalty/']
             });
-            args.template.should.match(/cicero-cli\/test\/data\/latedeliveryandpenalty$/);
+            args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
             args.target.should.match(/ergo/);
         });
         it('verbose flag specified', () => {

--- a/packages/cicero-core/.eslintrc.yml
+++ b/packages/cicero-core/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/cicero-engine/.eslintrc.yml
+++ b/packages/cicero-engine/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/cicero-server/.eslintrc.yml
+++ b/packages/cicero-server/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/cicero-test/.eslintrc.yml
+++ b/packages/cicero-test/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/cicero-tools/.eslintrc.yml
+++ b/packages/cicero-tools/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error

--- a/packages/generator-cicero-template/.eslintrc.yml
+++ b/packages/generator-cicero-template/.eslintrc.yml
@@ -12,7 +12,7 @@ rules:
         - error
         - 4
     linebreak-style:
-        - error
+        - warn
         - unix
     quotes:
         - error


### PR DESCRIPTION
Adds a Windows build to the Travis pipeline.

This OS is only used for testing the Cicero CLI.

This setup: 
1. validates that the Cicero CLI will work for Windows users (#219 , #408 , #207 ).
2. Ensures that we don't introduce regressions that break support for Windows.

![image](https://user-images.githubusercontent.com/7544022/65335690-ccee1380-dbbc-11e9-803d-e90a59a9272c.png)
