### PR TITLE
fix(CLI) generate text does not quote the output

### DIFF
--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -88,7 +88,7 @@ require('yargs')
             argv = Commands.validateGenerateTextArgs(argv);
             return Commands.generateText(argv.template, argv.data, argv.out, argv.warnings)
                 .then((result) => {
-                    if(result) {Logger.info(JSON.stringify(result));}
+                    if(result) {Logger.info(result);}
                 })
                 .catch((err) => {
                     Logger.error(err.message);


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #420
Nicer output for `cicero generateText`
