### PR TITLE
chore(gitignore): add thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ typings/
 
 # User Data
 userdata.json
+
+# Windows directory cache
+thumbs.db


### PR DESCRIPTION
### Changes

`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.

