### PR TITLE
fix(cicero-test) current time properly passed to parsing tests steps

### DIFF
--- a/packages/cicero-test/lib/steps.js
+++ b/packages/cicero-test/lib/steps.js
@@ -104,7 +104,7 @@ Given('that the contract says', async function (contractText) {
         this.request = clause.getTemplate().getMetadata().getRequest();
         this.clause = clause;
     }
-    this.clause.parse(contractText);
+    this.clause.parse(contractText,this.currentTime);
 });
 
 Given('that the contract data is', async function (contractData) {
@@ -125,7 +125,7 @@ Given('the default( sample) contract', async function () {
         this.request = clause.getTemplate().getMetadata().getRequest();
         this.clause = clause;
     }
-    this.clause.parse(this.clause.getTemplate().getMetadata().getSample());
+    this.clause.parse(this.clause.getTemplate().getMetadata().getSample(),this.currentTime);
 });
 
 Given('the state', function (actualState) {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #423 
- Test steps which parse sample text should be passed the current time.
