### PR TITLE
fix(core) Stricter semver check for template metadata

### DIFF
--- a/packages/cicero-core/src/metadata.js
+++ b/packages/cicero-core/src/metadata.js
@@ -76,11 +76,11 @@ class Metadata {
             throw new Error('Failed to find accordproject cicero version in package.json');
         }
 
-        if(!semver.valid(semver.coerce(packageJson.accordproject.cicero))){
-            throw new Error('The cicero version must be a valid semantic version (semver) number.');
+        if(!semver.validRange(packageJson.accordproject.cicero)){
+            throw new Error('The cicero version must be a valid semantic version (semver) range.');
         }
 
-        if(!semver.valid(semver.coerce(packageJson.version))){
+        if(!semver.valid(packageJson.version)){
             throw new Error('The template version must be a valid semantic version (semver) number.');
         }
 

--- a/packages/cicero-core/test/metadata.js
+++ b/packages/cicero-core/test/metadata.js
@@ -155,7 +155,20 @@ describe('Metadata', () => {
             }, null, {})).should.throw('The template version must be a valid semantic version (semver) number.');
         });
 
-        it('should throw an error if cicero version is not valid semver ', () => {
+        it('should throw an error if template version is not valid semver (1.0)', () => {
+            return (() => new Metadata({
+                name: 'template',
+                version: '1.0',
+                accordproject: {
+                    template: 'clause',
+                    ergo:'0.20.0-alpha.2',
+                    cicero:ciceroVersion,
+                    language: 'ergo'
+                },
+            }, null, {})).should.throw('The template version must be a valid semantic version (semver) number.');
+        });
+
+        it('should throw an error if cicero version is not valid semver range', () => {
             return (() => new Metadata({
                 name: 'template',
                 version: '1.0.0',
@@ -165,7 +178,7 @@ describe('Metadata', () => {
                     ergo: 'BLEH',
                     language: 'ergo'
                 },
-            }, null, {})).should.throw('The cicero version must be a valid semantic version (semver) number.');
+            }, null, {})).should.throw('The cicero version must be a valid semantic version (semver) range.');
         });
 
         it('should throw an error if cicero version is not valid semver for current version of cicero', () => {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #499
Stricter semver check for Cicero version range and template version.

### Flags
- This is a breaking change
