### PR TITLE
fix(cli) cicero normalize now passes wrapVariables option properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cicero",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -161,6 +161,7 @@ require('yargs')
         try {
             argv = Commands.validateNormalizeArgs(argv);
             const options = {
+                wrapVariables: argv.wrapVariables,
                 warnings: argv.warnings,
             };
             return Commands.normalize(argv.template, argv.sample, argv.overwrite, argv.output, argv.currentTime, options)

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -416,7 +416,7 @@ describe('#normalize', () => {
         result.should.eql(draftResponse);
     });
 
-    it('should fail normalizeing a clause using a template', async () => {
+    it('should fail normalizing a clause using a template', async () => {
         const result = await Commands.normalize(template, sampleErr, false, null);
         should.equal(result,undefined);
     });


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #506
Properly handles `--wrapVariables` option in `cicero normalize` CLI.

### Changes
- Passes option from CLI properly to underlying normalize command.
