### PR TITLE
chore(doc) Add Accord Project badge instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,14 @@ Join the Accord Project Technology Working Group [Slack channel][apslack] to get
 
 For code contributions, read our [CONTRIBUTING guide][contributing] and information for [DEVELOPERS][developers].
 
+### README Badge
+
+Using Accord Project? Add a README badge to let everyone know: [![accord project](https://img.shields.io/badge/powered%20by-accord%20project-19C6C8.svg)](https://www.accordproject.org/)
+
+```
+[![accord project](https://img.shields.io/badge/powered%20by-accord%20project-19C6C8.svg)](https://www.accordproject.org/)
+```
+
 ## License <a name="license"></a>
 
 Accord Project source code files are made available under the [Apache License, Version 2.0][apache].

--- a/packages/generator-cicero-template/generators/app/templates/README.md
+++ b/packages/generator-cicero-template/generators/app/templates/README.md
@@ -1,3 +1,4 @@
+[![accord project](https://img.shields.io/badge/powered%20by-accord%20project-19C6C8.svg)](https://www.accordproject.org/)
 
 # Accord Protocol Template: <%= data.templateName %>
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

Possible way to handle issue https://github.com/accordproject/techdocs/issues/81 and #487 

It currently shows as follows. It could be used by anyone using accord project.

<img width="1184" alt="Screenshot 2020-03-31 at 5 22 57 PM" src="https://user-images.githubusercontent.com/670099/78076397-56ed1500-7374-11ea-9019-98639d7b8a06.png">

### Flags
- Should it point to `www.accordproject.org` `docs.accordproject.org` or `gitHub.com/accordproject` ?
- Is this the right places in the README? I thought the general AP Section made more sense and we could apply the change across repositories.
