### PR TITLE
Added CICERO_DATA environment variable to Cicero Server API

### DIFF
--- a/packages/cicero-server/app.js
+++ b/packages/cicero-server/app.js
@@ -25,6 +25,8 @@ const Engine = require('@accordproject/cicero-engine').Engine;
 
 if(!process.env.CICERO_DIR) {
     throw new Error('You must set the CICERO_DIR environment variable.');
+} else if(!process.env.CICERO_DATA) {
+    throw new Error('You must set the CICERO_DATA environment variable.');
 }
 
 const PORT = process.env.PORT | 6001;
@@ -60,6 +62,7 @@ app.set('port', PORT);
  */
 app.post('/trigger/:template/:data', async function (req, httpResponse, next) {
     console.log('CICERO_DIR: ' + process.env.CICERO_DIR);
+    console.log('CICERO_DATA: ' + process.env.CICERO_DATA);
     console.log('Template: ' + req.params.template);
     console.log('Clause: ' + req.params.data);
     try {
@@ -107,6 +110,7 @@ app.post('/trigger/:template/:data', async function (req, httpResponse, next) {
  */
 app.post('/parse/:template/:data', async function (req, httpResponse, next) {
     console.log('CICERO_DIR: ' + process.env.CICERO_DIR);
+    console.log('CICERO_DATA: ' + process.env.CICERO_DATA);
     console.log('Template: ' + req.params.template);
     console.log('Clause: ' + req.params.data);
     try {
@@ -142,6 +146,7 @@ app.post('/parse/:template/:data', async function (req, httpResponse, next) {
  */
 app.post('/draft/:template/:data', async function (req, httpResponse, next) {
     console.log('CICERO_DIR: ' + process.env.CICERO_DIR);
+    console.log('CICERO_DATA: ' + process.env.CICERO_DATA);
     console.log('Template: ' + req.params.template);
     console.log('Clause: ' + req.params.data);
     try {
@@ -164,7 +169,7 @@ app.post('/draft/:template/:data', async function (req, httpResponse, next) {
 async function initClauseInstance(req) {
 
     const template = await Template.fromDirectory(`${process.env.CICERO_DIR}/${req.params.template}`);
-    const data = fs.readFileSync(`${process.env.CICERO_DIR}/${req.params.template}/${req.params.data}`);
+    const data = fs.readFileSync(`${process.env.CICERO_DATA}/${req.params.template}/${req.params.data}`);
     const clause = new Clause(template);
 
     if(req.params.data.endsWith('.json')) {

--- a/packages/cicero-server/test/app.js
+++ b/packages/cicero-server/test/app.js
@@ -38,11 +38,23 @@ const parseBody = {
 };
 const draftText = 'Late Delivery and Penalty. In case of delayed delivery except for Force Majeure cases, the Seller shall pay to the Buyer for every 9 days of delay penalty amounting to 7.0% of the total value of the Equipment whose delivery has been delayed. Any fractional part of a days is to be considered a full days. The total amount of penalty shall not however, exceed 2.0% of the total value of the Equipment involved in late delivery. If the delay is more than 2 weeks, the Buyer is entitled to terminate this Contract.';
 
-describe('cicero-server bad environment', () => {
+describe('cicero-server bad CICERO_DIR environment', () => {
 
     it('/should fail to start the server without CICERO_DIR defined', async () => {
         delete process.env.CICERO_DIR;
         (() => require('../app')).should.throw('You must set the CICERO_DIR environment variable.');
+        process.env.CICERO_DIR = './test/data';
+        decache('../app');
+    });
+
+});
+
+describe('cicero-server bad CICERO_DATA environment', () => {
+
+    it('/should fail to start the server without CICERO_DATA defined', async () => {
+        delete process.env.CICERO_DATA;
+        (() => require('../app')).should.throw('You must set the CICERO_DATA environment variable.');
+        process.env.CICERO_DATA = './test/data';
         decache('../app');
     });
 
@@ -52,6 +64,7 @@ describe('cicero-server', () => {
 
     before(()=>{
         process.env.CICERO_DIR = './test/data';
+        process.env.CICERO_DATA = './test/data';
         server = require('../app');
         request = request(server);
     });
@@ -122,4 +135,3 @@ describe('cicero-server', () => {
         server.close();
     });
 });
-


### PR DESCRIPTION
Signed-off-by: Martin Halford <martin@benext.io>

# Issue #514  
Added CICERO_DATA environment variable to Cicero Server API in order to allow data files to be located separately to the template archives.

### Changes
- Added reference to CICERO_DATA environment variable when creating `data` constant.
  - e.g. `${process.env.CICERO_DATA}/${req.params.template}/${req.params.data}`
- Added error handling to check that CICERO_DATA environment set prior to server start.
- Added test to check that error handling for CICERO_DATA environment is functioning.