### PR TITLE
feat(scripts/complete/cicero.sh): support for autocompletion

### DIFF
--- a/scripts/complete/cicero.sh
+++ b/scripts/complete/cicero.sh
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Auto-completion script for cicero commands
+# > cicero pa[TAB]
+# This will be auto-completed to cicero parse
+
+_cicero_entry='cicero'
+
+_cicero_commands='parse draft normalize trigger invoke initialize archive compile get'
+
+_cicero_options='--version --help'
+
+_cicero()
+{
+  local cur prev
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  case "$cur" in
+    -*) COMPREPLY=( $(compgen -W "${_cicero_options}" -- ${cur}) ) ;;
+    *) COMPREPLY=( $(compgen -W "${_cicero_commands}" -- ${cur}) ) ;;
+  esac
+
+  return 0
+}
+
+complete -F _cicero $_cicero_entry


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

# Issue #541 
Add support for autocompletion for `cicero` commands in bash.

### Test changes

1. Make sure you have the following snippet in your `~/.bashrc`.
```
if ! shopt -oq posix; then
 if [ -f /usr/share/bash-completion/bash_completion ]; then
   . /usr/share/bash-completion/bash_completion
 elif [ -f /etc/bash_completion ]; then
   . /etc/bash_completion
 fi
fi
```

2. Copy these changes inside `/etc/bash_completion.d/` by running this command. (You will need superuser permissions for doing so).
```
$ sudo cp ./scripts/complete/cicero.sh /etc/bash_completion.d/cicero
```

3. Reload bash configuration by executing
```
$ source ~/.bashrc
```
4. Test the command by typing `cicero` and pressing <kbd>Tab</kbd>. Here it a screencast of its working.
![cicero](https://user-images.githubusercontent.com/35191225/78892029-3749a100-7a86-11ea-869a-f227cdc94a84.gif)



### Flags
- This is a prototype for the autocompletion of `cicero` commands in bash.
- If it is approved, I will definitely work more on it so that is fully functional.
- Further, we can add this support in other shells like ZSH as well.