### PR TITLE
feature(server) New `/trigger/:template` endpoint

### DIFF
--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -117,8 +117,9 @@ require('yargs')
                 wrapVariables: argv.wrapVariables,
                 unquoteVariables: argv.unquoteVariables,
                 warnings: argv.warnings,
+                format: argv.format,
             };
-            return Commands.draft(argv.template, argv.data, argv.output, argv.currentTime, options, argv.format)
+            return Commands.draft(argv.template, argv.data, argv.output, argv.currentTime, options)
                 .then((result) => {
                     if(result) {Logger.info(result);}
                 })
@@ -183,8 +184,9 @@ require('yargs')
                 wrapVariables: argv.wrapVariables,
                 unquoteVariables: argv.unquoteVariables,
                 warnings: argv.warnings,
+                format: argv.format,
             };
-            return Commands.normalize(argv.template, argv.sample, argv.overwrite, argv.output, argv.currentTime, options, argv.format)
+            return Commands.normalize(argv.template, argv.sample, argv.overwrite, argv.output, argv.currentTime, options)
                 .then((result) => {
                     if(result) {Logger.info(result);}
                 })

--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -204,10 +204,9 @@ class Commands {
      * @param {string} outputPath - to the contract file
      * @param {string} currentTime - the definition of 'now'
      * @param {Object} [options] - an optional set of options
-     * @param {string} format - the target format
      * @returns {object} Promise to the result of parsing
      */
-    static draft(templatePath, dataPath, outputPath, currentTime, options, format) {
+    static draft(templatePath, dataPath, outputPath, currentTime, options) {
         let clause;
         const dataJson = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
 
@@ -215,7 +214,7 @@ class Commands {
             .then(async function (template) {
                 clause = new Clause(template);
                 clause.setData(dataJson);
-                const text = await clause.draft(options, currentTime, format);
+                const text = await clause.draft(options, currentTime);
                 if (outputPath) {
                     Logger.info('Creating file: ' + outputPath);
                     fs.writeFileSync(outputPath, text);
@@ -254,10 +253,9 @@ class Commands {
      * @param {string} outputPath - to the contract file
      * @param {string} currentTime - the definition of 'now'
      * @param {Object} [options] - an optional set of options
-     * @param {string} format - the target format
      * @returns {object} Promise to the result of parsing
      */
-    static normalize(templatePath, samplePath, overwrite, outputPath, currentTime, options, format) {
+    static normalize(templatePath, samplePath, overwrite, outputPath, currentTime, options) {
         let clause;
         const sampleText = fs.readFileSync(samplePath, 'utf8');
 
@@ -269,7 +267,7 @@ class Commands {
                     Logger.info('Creating file: ' + outputPath);
                     fs.writeFileSync(outputPath, JSON.stringify(clause.getData(),null,2));
                 }
-                const text = await clause.draft(options, currentTime, format);
+                const text = await clause.draft(options, currentTime);
                 if (outputPath) {
                     Logger.info('Creating file: ' + outputPath);
                     fs.writeFileSync(outputPath, text);

--- a/packages/cicero-core/src/parsermanager.js
+++ b/packages/cicero-core/src/parsermanager.js
@@ -540,7 +540,8 @@ class ParserManager {
      * @param {string} format - to the text generation
      * @return {string} the result of parsing and printing back the text
      */
-    formatText(text,options,format) {
+    formatText(text,options) {
+        const format = options ? options.format : null;
         if (!format) {
             let result = this.roundtripMarkdown(text);
             if (options && options.unquoteVariables) {
@@ -552,6 +553,8 @@ class ParserManager {
             const ciceroMarkTransformer = new CiceroMarkTransformer();
             const htmlTransformer = new HtmlTransformer();
             return htmlTransformer.toHtml(ciceroMarkTransformer.fromMarkdown(text,'json',{quoteVariables:!options.unquoteVariables}));
+        } else {
+            throw new Error('Unsupported format: ' + format);
         }
     }
 

--- a/packages/cicero-core/src/templateinstance.js
+++ b/packages/cicero-core/src/templateinstance.js
@@ -203,18 +203,17 @@ class TemplateInstance {
      * @param {*} [options] text generation options. options.wrapVariables encloses variables
      * and editable sections in '<variable ...' and '/>'
      * @param {string} currentTime - the definition of 'now' (optional)
-     * @param {string} format - the target format
      * @returns {string} the natural language text for the contract or clause; created by combining the structure of
      * the template with the JSON data for the clause.
      */
-    async draft(options, currentTime, format) {
+    async draft(options, currentTime) {
         if(!this.concertoData) {
             throw new Error('Data has not been set. Call setData or parse before calling this method.');
         }
 
         const markdownOptions = {
             '$class': 'org.accordproject.markdown.MarkdownOptions',
-            'wrapVariables': options && (options.wrapVariables || options.unquoteVariables || format === 'html') ? true : false,
+            'wrapVariables': options && (options.wrapVariables || options.unquoteVariables || options.format === 'html') ? true : false,
             'template': true
         };
         const logicManager = this.getLogicManager();
@@ -224,7 +223,7 @@ class TemplateInstance {
         return logicManager.compileLogic(false).then(async () => {
             const result = await this.getEngine().draft(logicManager,clauseId,contract,{},currentTime,markdownOptions);
             // Roundtrip the response through the Commonmark parser
-            return this.getTemplate().getParserManager().formatText(result.response, options, format);
+            return this.getTemplate().getParserManager().formatText(result.response, options);
         });
     }
 

--- a/packages/cicero-core/test/clause.js
+++ b/packages/cicero-core/test/clause.js
@@ -661,9 +661,49 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
                 }
             };
             clause.setData(data);
-            const newText = await clause.draft({unquoteVariables:true}, '2018-01-01T00:00:00-04:00', 'html');
+            const newText = await clause.draft({unquoteVariables:true, format:'html'});
             // remove the generated clause id
             newText.should.eql(text);
+        });
+
+        it('should throw when drafting to an unknown format', async function() {
+            const template = await Template.fromDirectory('./test/data/copyright-license', options);
+            const clause = new Clause(template);
+            const data = {
+                '$class': 'org.accordproject.copyrightlicense.CopyrightLicenseContract',
+                'contractId': 'e32a2ca7-78c9-4462-935f-487aad6e9c9b',
+                'effectiveDate': '2018-01-01T00:00:00.000-04:00',
+                'licensee': {
+                    '$class': 'org.accordproject.cicero.contract.AccordParty',
+                    'partyId': 'Me'
+                },
+                'licenseeState': 'NY',
+                'licenseeEntityType': 'Company',
+                'licenseeAddress': '1 Broadway',
+                'licensor': {
+                    '$class': 'org.accordproject.cicero.contract.AccordParty',
+                    'partyId': 'Myself'
+                },
+                'licensorState': 'NY',
+                'licensorEntityType': 'Company',
+                'licensorAddress': '2 Broadway',
+                'territory': 'United States',
+                'purposeDescription': 'stuff',
+                'workDescription': 'other stuff',
+                'paymentClause': {
+                    '$class': 'org.accordproject.copyrightlicense.PaymentClause',
+                    'clauseId': '25298022-2129-412c-ac60-b217ff766cb4',
+                    'amountText': 'one hundred US Dollars',
+                    'amount': {
+                        '$class': 'org.accordproject.money.MonetaryAmount',
+                        'doubleValue': 100,
+                        'currencyCode': 'USD'
+                    },
+                    'paymentProcedure': 'bank transfer'
+                }
+            };
+            clause.setData(data);
+            return clause.draft({unquoteVariables:true, format:'foo'}).should.be.rejectedWith('Unsupported format: foo');
         });
 
         it('should be able to parse an ulist block', async function() {


### PR DESCRIPTION
# Issue #508 

### Changes
- Add `/trigger/:template` endpoint taking contract data from the body rather than a file parameter
- `/trigger/:template/:data` is still here, but marked as deprecated
- Get test coverage for cicero server back up

### Flags
- Also includes some cleanup of `--format` handling, passed as option so it works with Cicero server as well, cleans up the code.

