### PR TITLE
fix(library) properly combines latest and cicero version options for …

### DIFF
--- a/packages/cicero-core/src/templatelibrary.js
+++ b/packages/cicero-core/src/templatelibrary.js
@@ -139,12 +139,12 @@ class TemplateLibrary {
         return rp(httpOptions)
             .then((templateIndex) => {
 
-                if(options && options.latestVersion) {
-                    templateIndex = TemplateLibrary.filterTemplateIndexLatestVersion(templateIndex);
-                }
-
                 if(options && options.ciceroVersion) {
                     templateIndex = TemplateLibrary.filterTemplateIndexCiceroVersion(templateIndex, options.ciceroVersion);
+                }
+
+                if(options && options.latestVersion) {
+                    templateIndex = TemplateLibrary.filterTemplateIndexLatestVersion(templateIndex);
                 }
 
                 globalTemplateIndexCache.set(cacheKey, templateIndex);

--- a/packages/cicero-core/test/templatelibrary.js
+++ b/packages/cicero-core/test/templatelibrary.js
@@ -71,6 +71,24 @@ describe('TemplateLibrary', () => {
             templateIndex.should.not.have.property('helloworld@0.2.0');
         });
 
+        it('should retrieve index for cicero version 0.20.0', async function() {
+            const templateLibrary = new TemplateLibrary();
+            const templateIndex = await templateLibrary.getTemplateIndex({ciceroVersion: '0.20.10'});
+            templateIndex.should.have.property('acceptance-of-delivery@0.13.0');
+            templateIndex.should.have.property('acceptance-of-delivery@0.13.1');
+            templateIndex.should.have.property('acceptance-of-delivery@0.13.2');
+            Object.keys(templateIndex).length.should.equal(109);
+        });
+
+        it('should retrieve index of latest templates for cicero version 0.20.0', async function() {
+            const templateLibrary = new TemplateLibrary();
+            const templateIndex = await templateLibrary.getTemplateIndex({ciceroVersion: '0.20.10',latestVersion: true});
+            templateIndex.should.not.have.property('acceptance-of-delivery@0.13.0');
+            templateIndex.should.not.have.property('acceptance-of-delivery@0.13.1');
+            templateIndex.should.have.property('acceptance-of-delivery@0.13.2');
+            Object.keys(templateIndex).length.should.equal(48);
+        });
+
         it('should retrieve latest version index for cicero version 0.21.0', async function() {
             const templateLibrary = new TemplateLibrary();
             const templateIndex = await templateLibrary.getTemplateIndex({latestVersion: true, ciceroVersion: '0.21.0'});


### PR DESCRIPTION
…template index

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #545 
Allows to properly combine `latestVersion` and `ciceroVersion` when filtering the template index. The issue is resolved as suggested by the issue's reporter.

### Changes
- combining `latestVersion` and `ciceroVersion` now returns the latest version of the templates compatible with the cicero version (rather than, in most cases, empty).
