### PR TITLE
fix(CLI) Revert change to how cicero parse returns error

### DIFF
--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -175,7 +175,7 @@ class Commands {
                 return clause.getData();
             })
             .catch((err) => {
-                Logger.error(err);
+                Logger.error(err.message);
             });
     }
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Do not print the stack on parsing error when calling `cicero parse` from the command line
