### PR TITLE
remove Slack sign-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/accordproject/cicero?color=bright-green" alt="GitHub license"></a>
   <a href="https://www.npmjs.com/package/@accordproject/cicero-cli"><img src="https://img.shields.io/npm/dm/@accordproject/cicero-cli" alt="downloads"></a>
   <a href="https://badge.fury.io/js/%40accordproject%2Fcicero-cli"><img src="https://badge.fury.io/js/%40accordproject%2Fcicero-cli.svg" alt="npm version"></a>
-  <a href="https://accord-project-slack-signup.herokuapp.com/">
-    <img src="https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue" alt="Join the Accord Project Slack"/>
-  </a>
 </p>
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ Copyright 2018-2019 Clause, Inc. All trademarks are the property of their respec
 [apdoc]: https://docs.accordproject.org/
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 
-[docspec]: https://docs.accordproject.org/docs/spec-overview.html
 [docwelcome]: https://docs.accordproject.org/docs/accordproject.html
 [dochighlevel]: https://docs.accordproject.org/docs/spec-concepts.html
 [docergo]: https://docs.accordproject.org/docs/logic-ergo.html


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

Remove the Slack button from the README, as the sign-up link doesn't work.