### PR TITLE
refactor(core) Clearer separation between contract template and contract instance

### DIFF
--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -167,7 +167,7 @@ class Commands {
 
         return Commands.loadTemplate(templatePath, options)
             .then((template) => {
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.parse(sampleText, currentTime, utcOffset, samplePath);
                 if (outputPath) {
                     Logger.info('Creating file: ' + outputPath);
@@ -214,7 +214,7 @@ class Commands {
 
         return Commands.loadTemplate(templatePath, options)
             .then(async function (template) {
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.setData(dataJson);
                 const drafted = clause.draft(options, currentTime, utcOffset);
                 if (outputPath) {
@@ -272,7 +272,7 @@ class Commands {
 
         return Commands.loadTemplate(templatePath, options)
             .then(async function (template) {
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.parse(sampleText, currentTime, utcOffset, samplePath);
                 if (outputPath) {
                     Logger.info('Creating file: ' + outputPath);
@@ -333,7 +333,7 @@ class Commands {
         return Commands.loadTemplate(templatePath, options)
             .then(async (template) => {
                 // Initialize clause
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.parse(sampleText, currentTime, utcOffset);
 
                 let stateJson;
@@ -401,7 +401,7 @@ class Commands {
         return Commands.loadTemplate(templatePath, options)
             .then(async (template) => {
                 // Initialize clause
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.parse(sampleText, currentTime, utcOffset);
 
                 let stateJson;
@@ -457,7 +457,7 @@ class Commands {
         return Commands.loadTemplate(templatePath, options)
             .then((template) => {
                 // Initialize clause
-                clause = new Clause(template);
+                clause = Clause.fromTemplate(template);
                 clause.parse(sampleText, currentTime, utcOffset);
 
                 return engine.init(clause, currentTime, utcOffset, paramsJson);

--- a/packages/cicero-core/src/clause.js
+++ b/packages/cicero-core/src/clause.js
@@ -25,7 +25,26 @@ const TemplateInstance = require('./templateinstance.js');
  * @class
  */
 class Clause extends TemplateInstance {
+    /**
+     * Create an instance from a Template.
+     * @param {Template} template  - the template for the instance
+     * @return {object} - the clause instance
+     */
+    static fromTemplate(template) {
+        // Setup
+        const metadata = template.getMetadata();
+        const logicManager = template.getLogicManager();
+        const grammar = template.getParserManager().getTemplate();
 
+        return new Clause(
+            metadata.getTemplateType(),
+            metadata.getIdentifier(),
+            logicManager,
+            grammar,
+            metadata.getRuntime(),
+            template,
+        );
+    }
 }
 
 module.exports = Clause;

--- a/packages/cicero-core/src/contract.js
+++ b/packages/cicero-core/src/contract.js
@@ -25,7 +25,26 @@ const TemplateInstance = require('./templateinstance.js');
  * @class
  */
 class Contract extends TemplateInstance {
+    /**
+     * Create an instance from a Template.
+     * @param {Template} template  - the template for the instance
+     * @return {object} - the contract instance
+     */
+    static fromTemplate(template) {
+        // Setup
+        const metadata = template.getMetadata();
+        const logicManager = template.getLogicManager();
+        const grammar = template.getParserManager().getTemplate();
 
+        return new Contract(
+            metadata.getTemplateType(),
+            metadata.getIdentifier(),
+            logicManager,
+            grammar,
+            metadata.getRuntime(),
+            template,
+        );
+    }
 }
 
 module.exports = Contract;

--- a/packages/cicero-core/src/template.js
+++ b/packages/cicero-core/src/template.js
@@ -22,6 +22,7 @@ const stringify = require('json-stable-stringify');
 const LogicManager = require('@accordproject/ergo-compiler').LogicManager;
 const TemplateLoader = require('./templateloader');
 const TemplateSaver = require('./templatesaver');
+const Util = require('./util');
 
 /**
  * A template for a legal clause or contract. A Template has a template model, request/response transaction types,
@@ -72,23 +73,7 @@ class Template {
      * @returns {ClassDeclaration} the template model for the template
      */
     getTemplateModel() {
-
-        let modelType = 'org.accordproject.contract.Contract';
-
-        if(this.getMetadata().getTemplateType() !== 0) {
-            modelType = 'org.accordproject.contract.Clause';
-        }
-        const templateModels = this.getIntrospector().getClassDeclarations().filter((item) => {
-            return !item.isAbstract() && Template.instanceOf(item,modelType);
-        });
-
-        if (templateModels.length > 1) {
-            throw new Error(`Found multiple instances of ${modelType} in ${this.metadata.getName()}. The model for the template must contain a single asset that extends ${modelType}.`);
-        } else if (templateModels.length === 0) {
-            throw new Error(`Failed to find an asset that extends ${modelType} in ${this.metadata.getName()}. The model for the template must contain a single asset that extends ${modelType}.`);
-        } else {
-            return templateModels[0];
-        }
+        return Util.getContractModel(this.logicManager, this.getMetadata().getTemplateType());
     }
 
     /**
@@ -131,7 +116,6 @@ class Template {
     getVersion() {
         return this.getMetadata().getVersion();
     }
-
 
     /**
      * Returns the description for this template
@@ -245,15 +229,6 @@ class Template {
      */
     getLogicManager() {
         return this.logicManager;
-    }
-
-    /**
-     * Provides access to the Introspector for this template. The Introspector
-     * is used to reflect on the types defined within this template.
-     * @return {Introspector} the Introspector for this template
-     */
-    getIntrospector() {
-        return this.logicManager.getIntrospector();
     }
 
     /**
@@ -405,30 +380,6 @@ class Template {
         return this.getScriptManager().getAllScripts().length > 0;
     }
 
-    /**
-     * Check to see if a ClassDeclaration is an instance of the specified fully qualified
-     * type name.
-     * @internal
-     * @param {ClassDeclaration} classDeclaration The class to test
-     * @param {String} fqt The fully qualified type name.
-     * @returns {boolean} True if classDeclaration an instance of the specified fully
-     * qualified type name, false otherwise.
-     */
-    static instanceOf(classDeclaration, fqt) {
-        // Check to see if this is an exact instance of the specified type.
-        if (classDeclaration.getFullyQualifiedName() === fqt) {
-            return true;
-        }
-        // Now walk the class hierachy looking to see if it's an instance of the specified type.
-        let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
-        while (superTypeDeclaration) {
-            if (superTypeDeclaration.getFullyQualifiedName() === fqt) {
-                return true;
-            }
-            superTypeDeclaration = superTypeDeclaration.getSuperTypeDeclaration();
-        }
-        return false;
-    }
 }
 
 module.exports = Template;

--- a/packages/cicero-core/src/templateinstance.js
+++ b/packages/cicero-core/src/templateinstance.js
@@ -17,6 +17,7 @@
 const Logger = require('@accordproject/concerto-core').Logger;
 const crypto = require('crypto');
 
+const ParserManager = require('@accordproject/markdown-template').ParserManager;
 const CiceroMarkTransformer = require('@accordproject/markdown-cicero').CiceroMarkTransformer;
 const SlateTransformer = require('@accordproject/markdown-slate').SlateTransformer;
 const TemplateMarkTransformer = require('@accordproject/markdown-template').TemplateMarkTransformer;
@@ -24,6 +25,8 @@ const HtmlTransformer = require('@accordproject/markdown-html').HtmlTransformer;
 
 // For formulas evaluation
 const ErgoEngine = require('@accordproject/ergo-engine/index.browser.js').EvalEngine;
+
+const Util = require('./util');
 
 /**
  * A TemplateInstance is an instance of a Clause or Contract template. It is executable business logic, linked to
@@ -36,49 +39,64 @@ const ErgoEngine = require('@accordproject/ergo-engine/index.browser.js').EvalEn
  * @class
  */
 class TemplateInstance {
-
     /**
-     * Create the Clause and link it to a Template.
-     * @param {Template} template  - the template for the clause
+     * Create an instance
+     * @param {number} instanceKind - the kind of instance (contract or clause)
+     * @param {string} prefix - the instance prefix
+     * @param {number} logicManager - the logic manager
+     * @param {string} grammar - the initial grammar
+     * @param {string} runtime - 'ergo' or 'es6'
+     * @param {Template} [template] - the template for the instance
      */
-    constructor(template) {
+    constructor(instanceKind, prefix, logicManager, grammar, runtime, template) {
         if (this.constructor === TemplateInstance) {
             throw new TypeError('Abstract class "TemplateInstance" cannot be instantiated directly.');
         }
+
+        this.instanceKind = instanceKind;
+        this.prefix = prefix;
+        this.logicManager = logicManager;
+        this.runtime = runtime;
         this.template = template;
-        this.data = null;
-        this.concertoData = null;
+
         this.ciceroMarkTransformer = new CiceroMarkTransformer();
         this.templateMarkTransformer = new TemplateMarkTransformer();
-        this.parserManager = this.template.getParserManager();
+        this.parserManager = new ParserManager(this.logicManager.getModelManager(), null, this.instanceKind);
         this.ergoEngine = new ErgoEngine();
 
-        // Set formula evaluation in parser manager
-        this.parserManager.setFormulaEval((name) => TemplateInstance.ciceroFormulaEval(
-            this.getLogicManager(),
-            this.getIdentifier(),
-            this.getEngine(),
-            name
-        ));
+        this.data = null;
+        this.concertoData = null;
+
+        // Initialize the parser
+        Util.initParser(
+            this.parserManager,
+            this.logicManager,
+            this.ergoEngine,
+            this.prefix,
+            this.instanceKind,
+            grammar,
+            this.runtime,
+        );
     }
 
     /**
-     * Set the data for the clause
+     * Set the data for the instance
      * @param {object} data  - the data for the clause, must be an instance of the
-     * template model for the clause's template. This should be a plain JS object
+     * model. This should be a plain JS object
      * and will be deserialized and validated into the Concerto object before assignment.
      */
     setData(data) {
         // verify that data is an instance of the template model
-        const templateModel = this.getTemplate().getTemplateModel();
+        const contractModel = Util.getContractModel(this.logicManager, this.instanceKind);
 
-        if (data.$class !== templateModel.getFullyQualifiedName()) {
-            throw new Error(`Invalid data, must be a valid instance of the template model ${templateModel.getFullyQualifiedName()} but got: ${JSON.stringify(data)} `);
+        if (data.$class !== contractModel.getFullyQualifiedName()) {
+            throw new Error(`Invalid data, must be a valid instance of the template model ${contractModel.getFullyQualifiedName()} but got: ${JSON.stringify(data)} `);
         }
 
         // downloadExternalDependencies the data using the template model
         Logger.debug('Setting clause data: ' + JSON.stringify(data));
-        const resource = this.getTemplate().getSerializer().fromJSON(data);
+        const serializer = this.logicManager.getModelManager().getSerializer();
+        const resource = serializer.fromJSON(data);
         resource.validate();
 
         // save the data
@@ -150,9 +168,7 @@ class TemplateInstance {
             throw new Error('Data has not been set. Call setData or parse before calling this method.');
         }
 
-        // Setup
-        const metadata = this.getTemplate().getMetadata();
-        const templateKind = metadata.getTemplateType() !== 0 ? 'clause' : 'contract';
+        const kind = this.instanceKind ? 'clause' : 'contract';
 
         // Get the data
         const data = this.getData();
@@ -161,7 +177,7 @@ class TemplateInstance {
         this.parserManager.setCurrentTime(currentTime, utcOffset);
 
         // Draft
-        const ciceroMark = this.templateMarkTransformer.draftCiceroMark(data, this.parserManager, templateKind, {});
+        const ciceroMark = this.templateMarkTransformer.draftCiceroMark(data, this.parserManager, kind, {});
         return this.formatCiceroMark(ciceroMark,options);
     }
 
@@ -200,9 +216,9 @@ class TemplateInstance {
     }
 
     /**
-     * Returns the identifier for this clause. The identifier is the identifier of
-     * the template plus '-' plus a hash of the data for the clause (if set).
-     * @return {String} the identifier of this clause
+     * Returns the identifier for this instance. The identifier is the instance prefix
+     * plus '-' plus a hash of the data for the instance (if set).
+     * @return {String} the identifier of this instance
      */
     getIdentifier() {
         let hash = '';
@@ -213,7 +229,7 @@ class TemplateInstance {
             hasher.update(textToHash);
             hash = '-' + hasher.digest('hex');
         }
-        return this.getTemplate().getIdentifier() + hash;
+        return this.prefix + hash;
     }
 
     /**
@@ -225,77 +241,44 @@ class TemplateInstance {
     }
 
     /**
+     * Returns the instance kind
+     * @return {number} the instance kind
+     */
+    getInstanceKind() {
+        return this.instanceKind;
+    }
+
+    /**
      * Returns the template logic for this clause
      * @return {LogicManager} the template for this clause
      */
     getLogicManager() {
-        return this.template.getLogicManager();
+        return this.logicManager;
     }
 
     /**
-     * Returns a JSON representation of the clause
+     * Returns a JSON representation of the instance
      * @return {object} the JS object for serialization
      */
     toJSON() {
         return {
-            template: this.getTemplate().getIdentifier(),
+            template: this.prefix,
             data: this.getData()
         };
     }
 
     /**
-     * Constructs a function for formula evaluation based for this template instance
-     * @param {*} logicManager - the logic manager
-     * @param {string} clauseId - this instance identifier
-     * @param {*} ergoEngine - the evaluation engine
-     * @param {string} name - the name of the formula
-     * @return {*} A function from formula code + input data to result
-     */
-    static ciceroFormulaEval(logicManager, clauseId, ergoEngine, name) {
-        return (code,data, currentTime, utcOffset) => {
-            const result = ergoEngine.calculate(logicManager, clauseId, name, data, currentTime, utcOffset, null);
-            // console.log('Formula result: ' + JSON.stringify(result.response));
-            return result.response;
-        };
-    }
-
-    /**
-     * Utility to rebuild a parser when the grammar changes
-     * @param {*} parserManager - the parser manager
-     * @param {*} logicManager - the logic manager
-     * @param {*} ergoEngine - the evaluation engine
-     * @param {string} templateName - this template name
+     * To rebuild the parser when the grammar changes
      * @param {string} grammar - the new grammar
      */
-    static rebuildParser(parserManager, logicManager, ergoEngine, templateName, grammar) {
-        // Update template in parser manager
-        parserManager.setTemplate(grammar);
-
-        // Rebuild parser
-        parserManager.buildParser();
-
-        // Process formulas
-        const oldFormulas = logicManager.getScriptManager().sourceTemplates;
-        const newFormulas = parserManager.getFormulas();
-
-        if (oldFormulas.length > 0 || newFormulas.length > 0) {
-            // Reset formulas
-            logicManager.getScriptManager().sourceTemplates = [];
-            newFormulas.forEach( (x) => {
-                logicManager.addTemplateFile(x.code, x.name);
-            });
-
-            // Re-set formula evaluation hook
-            parserManager.setFormulaEval((name) => TemplateInstance.ciceroFormulaEval(
-                logicManager,
-                templateName,
-                ergoEngine,
-                name
-            ));
-
-            // Re-compile formulas
-            logicManager.compileLogicSync(true);
-        }
+    rebuildParser(grammar) {
+        Util.rebuildParser(
+            this.parserManager,
+            this.logicManager,
+            this.ergoEngine,
+            this.prefix,
+            grammar
+        );
     }
 }
 

--- a/packages/cicero-core/src/templateloader.js
+++ b/packages/cicero-core/src/templateloader.js
@@ -23,10 +23,13 @@ const languageTagRegex = require('ietf-language-tag-regex');
 const DefaultArchiveLoader = require('./loaders/defaultarchiveloader');
 const FileLoader = require('@accordproject/ergo-compiler').FileLoader;
 const Logger = require('@accordproject/concerto-core').Logger;
+const ErgoEngine = require('@accordproject/ergo-engine/index.browser.js').EvalEngine;
 
 // Matches 'sample.md' or 'sample_TAG.md' where TAG is an IETF language tag (BCP 47)
 const IETF_REGEXP = languageTagRegex({ exact: false }).toString().slice(1,-2);
 const SAMPLE_FILE_REGEXP = xregexp('text[/\\\\]sample(_(' + IETF_REGEXP + '))?.md$');
+
+const Util = require('./util');
 
 /**
  * A utility class to create templates from data sources.
@@ -85,11 +88,6 @@ class TemplateLoader extends FileLoader {
         Logger.debug(method, 'Setting grammar');
         if(!grammar) {
             throw new Error('A template must contain a grammar.tem.md file.');
-        } else {
-            const templateKind = template.getMetadata().getTemplateType() !== 0 ? 'clause' : 'contract';
-            template.parserManager.setTemplate(grammar);
-            template.parserManager.setTemplateKind(templateKind);
-            template.parserManager.buildParser();
         }
 
         // load and add the ergo files
@@ -108,7 +106,15 @@ class TemplateLoader extends FileLoader {
             });
         }
 
-        TemplateLoader.registerFormulas(template.parserManager,template.getLogicManager());
+        Util.initParser(
+            template.parserManager,
+            template.getLogicManager(),
+            new ErgoEngine(),
+            template.getIdentifier(),
+            template.getMetadata().getTemplateType(),
+            grammar,
+            template.getMetadata().getRuntime() === 'ergo' // Whether to compile or not
+        );
 
         // check the integrity of the model and logic of the template
         template.validate();
@@ -193,12 +199,6 @@ class TemplateLoader extends FileLoader {
 
         if(!grammar) {
             throw new Error('A template must either contain a grammar.tem.md file.');
-        } else {
-            const templateKind = template.getMetadata().getTemplateType() !== 0 ? 'clause' : 'contract';
-            template.parserManager.setTemplate(grammar);
-            template.parserManager.setTemplateKind(templateKind);
-            template.parserManager.buildParser();
-            Logger.debug(method, 'Loaded grammar.tem.md', grammar);
         }
 
         Logger.debug(method, 'Loaded grammar.tem.md');
@@ -223,24 +223,20 @@ class TemplateLoader extends FileLoader {
             });
         }
 
-        TemplateLoader.registerFormulas(template.parserManager,template.getLogicManager());
+        Util.initParser(
+            template.parserManager,
+            template.getLogicManager(),
+            new ErgoEngine(),
+            template.getIdentifier(),
+            template.getMetadata().getTemplateType(),
+            grammar,
+            template.getMetadata().getRuntime() === 'ergo' // Whether to compile or not
+        );
 
         // check the template
         template.validate();
 
         return template;
-    }
-
-    /**
-     * Prepare the text for parsing (normalizes new lines, etc)
-     * @param {*} parserManager - the parser manager
-     * @param {*} logicManager - the logic manager
-     */
-    static registerFormulas(parserManager,logicManager){
-        const formulas = parserManager.getFormulas();
-        formulas.forEach(x => {
-            logicManager.addTemplateFile(x.code,x.name);
-        });
     }
 
     /**

--- a/packages/cicero-core/src/util.js
+++ b/packages/cicero-core/src/util.js
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * Check to see if a ClassDeclaration is an instance of the specified fully qualified
+ * type name.
+ * @internal
+ * @param {ClassDeclaration} classDeclaration The class to test
+ * @param {String} fqt The fully qualified type name.
+ * @returns {boolean} True if classDeclaration an instance of the specified fully
+ * qualified type name, false otherwise.
+ */
+function instanceOf(classDeclaration, fqt) {
+    // Check to see if this is an exact instance of the specified type.
+    if (classDeclaration.getFullyQualifiedName() === fqt) {
+        return true;
+    }
+    // Now walk the class hierachy looking to see if it's an instance of the specified type.
+    let superTypeDeclaration = classDeclaration.getSuperTypeDeclaration();
+    while (superTypeDeclaration) {
+        if (superTypeDeclaration.getFullyQualifiedName() === fqt) {
+            return true;
+        }
+        superTypeDeclaration = superTypeDeclaration.getSuperTypeDeclaration();
+    }
+    return false;
+}
+
+/**
+ * Returns the model for the contract or clause
+ * @param {object} logicManager - the logic manager
+ * @param {number} kind - the template kind
+ * @returns {ClassDeclaration} the template model
+ */
+function getContractModel(logicManager, kind) {
+    let modelType = 'org.accordproject.contract.Contract';
+
+    if(kind !== 0) {
+        modelType = 'org.accordproject.contract.Clause';
+    }
+    const templateModels = logicManager.getIntrospector().getClassDeclarations().filter((item) => {
+        return !item.isAbstract() && instanceOf(item, modelType);
+    });
+
+    if (templateModels.length > 1) {
+        throw new Error(`Found multiple instances of ${modelType} in ${this.metadata.getName()}. The model for the template must contain a single asset that extends ${modelType}.`);
+    } else if (templateModels.length === 0) {
+        throw new Error(`Failed to find an asset that extends ${modelType} in ${this.metadata.getName()}. The model for the template must contain a single asset that extends ${modelType}.`);
+    } else {
+        return templateModels[0];
+    }
+}
+
+/**
+ * Constructs a function for formula evaluation based for this instance
+ * @param {*} logicManager - the logic manager
+ * @param {string} clauseId - this instance identifier
+ * @param {*} ergoEngine - the evaluation engine
+ * @param {string} name - the name of the formula
+ * @return {*} A function from formula code + input data to result
+ */
+function ciceroFormulaEval(logicManager, clauseId, ergoEngine, name) {
+    return (code,data, currentTime, utcOffset) => {
+        const result = ergoEngine.calculate(logicManager, clauseId, name, data, currentTime, utcOffset, null);
+        // console.log('Formula result: ' + JSON.stringify(result.response));
+        return result.response;
+    };
+}
+
+/**
+ * Utility to initialize the parser with a grammar
+ * @param {*} parserManager - the parser manager
+ * @param {*} logicManager - the logic manager
+ * @param {*} ergoEngine - the evaluation engine
+ * @param {string} templateName - this template name
+ * @param {string} templateKind - this template kind (contract or clause)
+ * @param {string} grammar - the grammar
+ * @param {boolean} runtime - 'ergo' or 'es6'
+ */
+function initParser(parserManager, logicManager, ergoEngine, templateName, templateKind, grammar, runtime) {
+    const kind = templateKind !== 0 ? 'clause' : 'contract';
+    parserManager.setTemplate(grammar);
+    parserManager.setTemplateKind(kind);
+    parserManager.buildParser();
+
+    const formulas = parserManager.getFormulas();
+    formulas.forEach(x => {
+        logicManager.addTemplateFile(x.code,x.name);
+    });
+
+    // Set formula evaluation in parser manager
+    parserManager.setFormulaEval((name) => ciceroFormulaEval(
+        logicManager,
+        templateName,
+        ergoEngine,
+        name
+    ));
+
+    // Compile formulas
+    if (runtime === 'ergo') {
+        logicManager.compileLogicSync(true);
+    }
+}
+
+/**
+ * Utility to rebuild a parser when the grammar changes
+ * @param {*} parserManager - the parser manager
+ * @param {*} logicManager - the logic manager
+ * @param {*} ergoEngine - the evaluation engine
+ * @param {string} templateName - this template name
+ * @param {string} grammar - the new grammar
+ */
+function rebuildParser(parserManager, logicManager, ergoEngine, templateName, grammar) {
+    // Update template in parser manager
+    parserManager.setTemplate(grammar);
+
+    // Rebuild parser
+    parserManager.buildParser();
+
+    // Process formulas
+    const oldFormulas = logicManager.getScriptManager().sourceTemplates;
+    const newFormulas = parserManager.getFormulas();
+
+    if (oldFormulas.length > 0 || newFormulas.length > 0) {
+        // Reset formulas
+        logicManager.getScriptManager().sourceTemplates = [];
+        newFormulas.forEach( (x) => {
+            logicManager.addTemplateFile(x.code, x.name);
+        });
+
+        // Re-set formula evaluation hook
+        parserManager.setFormulaEval((name) => ciceroFormulaEval(
+            logicManager,
+            templateName,
+            ergoEngine,
+            name
+        ));
+
+        // Re-compile formulas
+        logicManager.compileLogicSync(true);
+    }
+}
+
+module.exports = { getContractModel, ciceroFormulaEval, initParser, rebuildParser };

--- a/packages/cicero-core/test/clause.js
+++ b/packages/cicero-core/test/clause.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const Template = require('../lib/template');
-const TemplateInstance = require('../lib/templateinstance');
 const TemplateLoader = require('../lib/templateloader');
 const Clause = require('../lib/clause');
 
@@ -77,14 +76,14 @@ describe('Clause', () => {
 
         it('should create a clause for a latedeliveryandpenalty template', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.should.not.be.null;
             clause.getLogicManager().should.not.be.null;
         });
 
         it('should create a clause for a conga template', async function() {
             const template = await Template.fromDirectory('./test/data/conga', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.should.not.be.null;
         });
 
@@ -117,7 +116,7 @@ describe('Clause', () => {
 
         it('should be able to set data', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
 
             // check that we can set/get a valid template model
             const data = {
@@ -146,7 +145,7 @@ describe('Clause', () => {
         });
         it('should throw error for bad $class', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = {
                 $class: 'bad.class.name'
             };
@@ -158,7 +157,7 @@ describe('Clause', () => {
 
         it('should get a JSON representation of a clause', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = {
                 $class: 'io.clause.latedeliveryandpenalty.TemplateModel',
                 clauseId: 'c0884078-882d-42e0-87d6-4cc824b4f194',
@@ -189,7 +188,7 @@ describe('Clause', () => {
 
         it('should be able to set the data from latedeliveryandpenalty natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyInput);
             const data = {
                 $class: 'io.clause.latedeliveryandpenalty.TemplateModel',
@@ -217,7 +216,7 @@ describe('Clause', () => {
 
         it('should be able to set the data from latedeliveryandpenalty natural language text (with CR)', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-cr', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyCrInput);
             const data = {
                 $class: 'io.clause.latedeliveryandpenalty.TemplateModel',
@@ -245,7 +244,7 @@ describe('Clause', () => {
 
         it('should be able to set the data from latedeliveryandpenalty natural language text (with a Period)', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyPeriodInput);
             const data = {
                 $class: 'org.accordproject.simplelatedeliveryandpenalty.SimpleLateDeliveryAndPenaltyContract',
@@ -273,7 +272,7 @@ describe('Clause', () => {
 
         it('should be able to set the data from conga natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/conga', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testCongaInput);
             const data = {
                 $class: 'org.accordproject.conga.TemplateModel',
@@ -290,19 +289,19 @@ describe('Clause', () => {
 
         it('should throw an error for empty text', async function() {
             const template = await Template.fromDirectory('./test/data/conga', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             (()=> clause.parse('')).should.throw('Parse error at line 1 column 1');
         });
 
         it('should throw an error for non-matching text', async function() {
             const template = await Template.fromDirectory('./test/data/conga', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             (()=> clause.parse(testCongaErr)).should.throw('Parse error at line 1 column 13');
         });
 
         it('should be able to set the data for a text-only clause', async function() {
             const template = await Template.fromDirectory('./test/data/text-only', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testTextOnlyInput);
             const data = {
                 $class: 'io.clause.latedeliveryandpenalty.TemplateModel',
@@ -337,7 +336,7 @@ describe('Clause', () => {
 
         it('should be able to parse an if-else block (true)', async function() {
             const template = await Template.fromDirectory('./test/data/block-ifelse', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse('I\'m active');
             const data = {
                 '$class': 'org.accordproject.volumediscountlist.VolumeDiscountContract',
@@ -351,7 +350,7 @@ describe('Clause', () => {
 
         it('should be able to parse an if-else block (false)', async function() {
             const template = await Template.fromDirectory('./test/data/block-ifelse', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse('I\'m inactive');
             const data = {
                 '$class': 'org.accordproject.volumediscountlist.VolumeDiscountContract',
@@ -365,7 +364,7 @@ describe('Clause', () => {
 
         it('should not be able to parse an if-else block if the text is neither options', async function() {
             const template = await Template.fromDirectory('./test/data/block-ifelse', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             (()=> clause.parse('I\'m not active')).should.throw(`Parse error at line 1 column 1
 I'm not active
 ^^^^^^^^^^^^
@@ -382,7 +381,7 @@ Expected: 'I'm active' or 'I'm inactive'`);
 
         it('should be able to parse an olist block', async function() {
             const template = await Template.fromDirectory('./test/data/block-olist', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(`This is a list
 1. 0.0$ million <= Volume < 1.0$ million : 3.1%
 2. 1.0$ million <= Volume < 10.0$ million : 3.1%
@@ -421,7 +420,7 @@ This is more text
 
         it('should be able to draft an olist block', async function() {
             const template = await Template.fromDirectory('./test/data/block-olist', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const text = `This is a list
 1. 0.0$ million <= Volume < 1.0$ million : 3.1%
 2. 1.0$ million <= Volume < 10.0$ million : 3.1%
@@ -459,7 +458,7 @@ This is more text`;
 
         it('should be able to draft a copyright license', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = copyrightData;
             clause.setData(data);
             const newText = clause.draft();
@@ -468,7 +467,7 @@ This is more text`;
 
         it('should be able to draft a copyright license (unquote variables)', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const text = `Copyright License Agreement
 
 This COPYRIGHT LICENSE AGREEMENT (the "Agreement"), dated as of 01/01/2018 (the "Effective Date"), is made by and between Me ("Licensee"), a NY Company with offices located at 1 Broadway, and Myself ("Licensor"), a NY Company with offices located at 2 Broadway.
@@ -532,7 +531,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should be able to draft a copyright license (html)', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const text = `<html>
 <body>
 <div class="document">
@@ -563,7 +562,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should be able to draft a copyright license (markdown_cicero)', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = copyrightData;
             clause.setData(data);
             const newText = clause.draft({format:'markdown_cicero'});
@@ -572,7 +571,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should be able to draft a copyright license (slate)', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = copyrightData;
             clause.setData(data);
             const newText = clause.draft({format:'slate'});
@@ -581,7 +580,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should be able to draft a copyright license (ciceromark_parsed)', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = copyrightData;
             clause.setData(data);
             const newText = clause.draft({format:'ciceromark_parsed'});
@@ -590,7 +589,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should throw when drafting to an unknown format', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const data = {
                 '$class': 'org.accordproject.copyrightlicense.CopyrightLicenseContract',
                 'contractId': 'e32a2ca7-78c9-4462-935f-487aad6e9c9b',
@@ -624,7 +623,7 @@ Assignment. Licensee may freely assign or otherwise transfer all or any of its r
 
         it('should be able to parse an ulist block', async function() {
             const template = await Template.fromDirectory('./test/data/block-ulist', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const text = `This is a list
 - 0.0$ million <= Volume < 1.0$ million : 3.1%
 - 1.0$ million <= Volume < 10.0$ million : 3.1%
@@ -663,7 +662,7 @@ This is more text`;
 
         it('should be able to draft an ulist block', async function() {
             const template = await Template.fromDirectory('./test/data/block-ulist', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const text = `This is a list
 -  0.0$ million <= Volume < 1.0$ million : 3.1%
 -  1.0$ million <= Volume < 10.0$ million : 3.1%
@@ -701,7 +700,7 @@ This is more text`;
 
         it('should be able to parse a join block', async function() {
             const template = await Template.fromDirectory('./test/data/block-join', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse('This is a list: 3.1%, 3.3%, 2.9% (And more Text)');
             const data = {
                 '$class': 'org.accordproject.volumediscountlist.VolumeDiscountContract',
@@ -728,7 +727,7 @@ This is more text`;
 
         it('should be able to parse an ergo expressions', async function() {
             const template = await Template.fromDirectory('./test/data/block-ergo', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse('This is a list: 3.1%, 3.3%, 2.9% (Average: {{%Some text%}})');
             const data = {
                 '$class': 'org.accordproject.volumediscountlist.VolumeDiscountContract',
@@ -759,7 +758,7 @@ This is more text`;
 
         it('should be able to draft with interest rates formula', async function() {
             const template = await Template.fromDirectory('./test/data/fixed-interests', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(`## Fixed rate loan
 
 This is a _fixed interest_ loan to the amount of £100,000.00
@@ -783,7 +782,7 @@ and monthly payments of {{%"£667.00"%}}`));
 
         it('should be able to roundtrip latedelivery natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyInput);
             const nl = clause.draft();
             nl.should.equal(TemplateLoader.normalizeText(testLatePenaltyInput));
@@ -791,7 +790,7 @@ and monthly payments of {{%"£667.00"%}}`));
 
         it('should be able to generate natural language text (conditional true)', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyInput);
             const nl = clause.draft();
             nl.should.equal(`Late Delivery and Penalty
@@ -805,7 +804,7 @@ In case of delayed delivery except for Force Majeure cases, the Seller shall pay
 
         it('should be able to generate natural language text (conditional false)', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyInputNoForce);
             const nl = clause.draft();
             nl.should.equal(`Late Delivery and Penalty
@@ -819,7 +818,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to generate natural language text (formatted dates)', async function() {
             const template = await Template.fromDirectory('./test/data/formatted-dates-DD_MM_YYYY', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse('dateTimeProperty: 01/12/2018');
             const nl = clause.draft();
             nl.should.equal('dateTimeProperty: 01/12/2018');
@@ -827,7 +826,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to roundtrip latedelivery natural language text (with a Period)', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty-period', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testLatePenaltyPeriodInput);
             const nl = clause.draft();
             nl.should.equal(TemplateLoader.normalizeText(testLatePenaltyPeriodInput));
@@ -835,7 +834,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to roundtrip conga natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/conga', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testCongaInput);
             const nl = clause.draft();
             nl.should.equal(TemplateLoader.normalizeText(testCongaInput));
@@ -843,7 +842,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to roundtrip alltypes natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/alltypes', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testAllTypesInput);
             const nl = clause.draft();
             nl.should.equal(TemplateLoader.normalizeText(testAllTypesInput));
@@ -851,7 +850,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to roundtrip allblocks natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/allblocks', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(testAllBlocksInput);
             const nl = clause.draft();
             nl.should.equal(TemplateLoader.normalizeText(testAllBlocksInput));
@@ -859,7 +858,7 @@ In case of delayed delivery the Seller shall pay to the Buyer for every 9 days o
 
         it('should be able to update the template grammar and draft', async function() {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty', options);
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             const newGrammar = `Late Delivery and Penalty
 ====
 In case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{{/if}} the Seller shall pay to the Buyer for every {{penaltyDuration}} of delay penalty amounting to {{penaltyPercentage}}% of the total value of the Equipment whose delivery has been delayed. 
@@ -870,11 +869,7 @@ In case of delayed delivery{{#if forceMajeure}} except for Force Majeure cases,{
 
 Adding all precentages in this clause yields: {{% capPercentage + penaltyPercentage %}}.`;
             // Update the grammar
-            TemplateInstance.rebuildParser(
-                clause.getTemplate().getParserManager(),
-                clause.getTemplate().getLogicManager(),
-                clause.getEngine(),
-                clause.getIdentifier(),
+            clause.rebuildParser(
                 newGrammar,
             );
             // Parse again

--- a/packages/cicero-core/test/contract.js
+++ b/packages/cicero-core/test/contract.js
@@ -32,7 +32,7 @@ describe('Contract', () => {
     describe('#parse', () => {
         it('should be able to set the data from copyright-license natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license', { offline: true });
-            const contract = new Contract(template);
+            const contract = Contract.fromTemplate(template);
             contract.parse(sampleText);
         });
     });
@@ -41,7 +41,7 @@ describe('Contract', () => {
 
         it('should be able to roundtrip copyright-license natural language text', async function() {
             const template = await Template.fromDirectory('./test/data/copyright-license');
-            const contract = new Contract(template);
+            const contract = Contract.fromTemplate(template);
             contract.parse(sampleText);
             const nl = await contract.draft();
             nl.should.equal(TemplateLoader.normalizeText(sampleText));

--- a/packages/cicero-core/test/template.js
+++ b/packages/cicero-core/test/template.js
@@ -341,7 +341,7 @@ at the yearly interest rate of 2.5%
 with a loan term of 15,
 and monthly payments of {{%I'm not sure which amount right now%}}
 `;
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(sampleText);
             const result = clause.getData();
             delete result.clauseId;
@@ -377,7 +377,7 @@ and monthly payments of {{%I'm not sure which amount right now%}}
                 'clauseId': '0bb38858-24b3-4853-b8c2-2fa3b93dce8d'
             };
 
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.setData(data);
             const result = clause.draft();
 
@@ -670,7 +670,7 @@ and monthly payments of {{%"£667.00"%}}`;
             template.getParserManager().getParser().should.not.be.null;
 
             const sampleText = fs.readFileSync('./test/data/latedeliveryandpenalty/text/sample.md', 'utf8');
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(sampleText);
             const result = clause.getData();
             delete result.clauseId;
@@ -701,7 +701,7 @@ and monthly payments of {{%"£667.00"%}}`;
             template.getParserManager().getParser().should.not.be.null;
 
             const sampleText = fs.readFileSync('./test/data/copyright-license/text/sample.md', 'utf8');
-            const clause = new Clause(template);
+            const clause = Clause.fromTemplate(template);
             clause.parse(sampleText);
             const result = clause.getData();
             delete result.contractId;

--- a/packages/cicero-core/test/templateinstance.js
+++ b/packages/cicero-core/test/templateinstance.js
@@ -27,7 +27,7 @@ describe('TemplateInstance', () => {
     describe('#constructor', () => {
 
         it('should fail to instantiate', async function() {
-            (() => new TemplateInstance(null)).should.throw('Abstract class "TemplateInstance" cannot be instantiated directly.');
+            (() => new TemplateInstance()).should.throw('Abstract class "TemplateInstance" cannot be instantiated directly.');
         });
 
     });

--- a/packages/cicero-engine/test/engine.js
+++ b/packages/cicero-engine/test/engine.js
@@ -46,9 +46,9 @@ describe('EngineLatePenalty', () => {
 
     beforeEach(async function () {
         engine = new Engine();
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(testLatePenaltyInput);
-        clause2 = new Clause(template2);
+        clause2 = Clause.fromTemplate(template2);
         clause2.parse(testLatePenaltyPeriodInput);
     });
 
@@ -174,7 +174,7 @@ describe('EngineLatePenalty (JavaScript)', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty_js', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(testLatePenaltyInput);
     });
 
@@ -232,7 +232,7 @@ describe('EngineHelloWorld', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/helloworld', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(helloWorldInput);
     });
 
@@ -294,7 +294,7 @@ describe('EngineHelloWorldState', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/helloworldstate', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(helloWorldInput);
     });
 
@@ -321,7 +321,7 @@ describe('EngineHelloModule', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/hellomodule', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(helloWorldInput);
     });
 
@@ -352,7 +352,7 @@ describe('EngineHelloEmit', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/helloemit', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(helloEmitInput);
     });
 
@@ -385,7 +385,7 @@ describe('EngineHelloEmitInit', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/helloemitinit', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(helloEmitInitInput);
     });
 
@@ -412,7 +412,7 @@ describe('EngineSaft', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/saft', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(saftInput);
     });
 
@@ -443,7 +443,7 @@ describe('BogusClauses', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/no-logic', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(testNoLogic);
     });
 
@@ -485,7 +485,7 @@ describe('EngineInstallmentSaleErgo', () => {
     beforeEach(async function () {
         engine = new Engine();
         const template = await Template.fromDirectory('./test/data/installment-sale-ergo', options);
-        clause = new Clause(template);
+        clause = Clause.fromTemplate(template);
         clause.parse(testLatePenaltyInput);
     });
 

--- a/packages/cicero-server/app.js
+++ b/packages/cicero-server/app.js
@@ -169,7 +169,7 @@ app.post('/draft/:template', async function (req, httpResponse, next) {
  */
 async function initTemplateInstance(req) {
     const template = await Template.fromDirectory(`${process.env.CICERO_DIR}/${req.params.template}`);
-    return new Clause(template);
+    return Clause.fromTemplate(template);
 }
 
 const server = app.listen(app.get('port'), function () {

--- a/packages/cicero-test/lib/steps.js
+++ b/packages/cicero-test/lib/steps.js
@@ -73,7 +73,7 @@ async function trigger(engine,clause,request,state,currentTime,utcOffset) {
  */
 async function loadClause(templateDir) {
     const template = await Template.fromDirectory(templateDir);
-    return new Clause(template);
+    return Clause.fromTemplate(template);
 }
 
 Before(function () {


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

WIP

- Reduce dependency of (contract) instances to templates so they can be created more independently
- Add `fromTemplate` method to create an instance from a template

