### PR TITLE
feat(cicero-cli): add --data option to initilize, invoke and trigger commands

### DIFF
--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -226,7 +226,13 @@ require('yargs')
         });
         yargs.option('sample', {
             describe: 'path to the contract text',
-            type: 'string'
+            type: 'string',
+            default: null,
+        });
+        yargs.option('data', {
+            describe: 'path to JSON data',
+            type: 'string',
+            default: null,
         });
         yargs.option('request', {
             describe: 'path to the JSON request',
@@ -264,7 +270,7 @@ require('yargs')
                 offline: argv.offline,
                 warnings: argv.warnings,
             };
-            return Commands.trigger(argv.template, argv.sample, argv.request, argv.state, argv.currentTime, argv.utcOffset, options)
+            return Commands.trigger(argv.template, argv.sample, argv.data, argv.request, argv.state, argv.currentTime, argv.utcOffset, options)
                 .then((result) => {
                     if(result) {Logger.info(JSON.stringify(result));}
                 })
@@ -282,7 +288,13 @@ require('yargs')
         });
         yargs.option('sample', {
             describe: 'path to the contract text',
-            type: 'string'
+            type: 'string',
+            default: null,
+        });
+        yargs.option('data', {
+            describe: 'path to JSON data',
+            type: 'string',
+            default: null,
         });
         yargs.option('clauseName', {
             describe: 'the name of the clause to invoke',
@@ -323,7 +335,7 @@ require('yargs')
                 offline: argv.offline,
                 warnings: argv.warnings,
             };
-            return Commands.invoke(argv.template, argv.sample, argv.clauseName, argv.params, argv.state, argv.currentTime, argv.utcOffset, options)
+            return Commands.invoke(argv.template, argv.sample, argv.data, argv.clauseName, argv.params, argv.state, argv.currentTime, argv.utcOffset, options)
                 .then((result) => {
                     if(result) {Logger.info(JSON.stringify(result));}
                 })
@@ -341,7 +353,13 @@ require('yargs')
         });
         yargs.option('sample', {
             describe: 'path to the contract text',
-            type: 'string'
+            type: 'string',
+            default: null,
+        });
+        yargs.option('data', {
+            describe: 'path to JSON data',
+            type: 'string',
+            default: null,
         });
         yargs.option('params', {
             describe: 'path to the parameters',
@@ -375,7 +393,7 @@ require('yargs')
                 offline: argv.offline,
                 warnings: argv.warnings,
             };
-            return Commands.initialize(argv.template, argv.sample, argv.params, argv.currentTime, argv.utcOffset, options)
+            return Commands.initialize(argv.template, argv.sample, argv.data, argv.params, argv.currentTime, argv.utcOffset, options)
                 .then((result) => {
                     if(result) {Logger.info(JSON.stringify(result));}
                 })

--- a/packages/cicero-cli/test/data/helloworldstate/data.json
+++ b/packages/cicero-cli/test/data/helloworldstate/data.json
@@ -1,0 +1,6 @@
+{
+  "$class": "org.accordproject.helloworldstate.HelloWorldClause",
+  "name": "Fred Blogs",
+  "clauseId": "e15ff8fd-224c-4a11-8e8d-b92b74586080",
+  "$identifier": "e15ff8fd-224c-4a11-8e8d-b92b74586080"
+}

--- a/packages/cicero-cli/test/initialize.js
+++ b/packages/cicero-cli/test/initialize.js
@@ -27,10 +27,11 @@ const Commands = require('../lib/commands');
 const template = path.resolve(__dirname, 'data/helloworldstate/');
 const sample = path.resolve(__dirname, 'data/helloworldstate/', 'text/sample.md');
 const params = path.resolve(__dirname, 'data/helloworldstate/', 'params.json');
+const data = path.resolve(__dirname, 'data/helloworldstate/', 'data.json');
 
 describe('#initializeWithParameters', () => {
     it('should initialize with some parameters', async () => {
-        const response = await Commands.initialize(template, sample, params);
+        const response = await Commands.initialize(template, sample, data, params);
         response.state.$class.should.be.equal('org.accordproject.helloworldstate.HelloWorldState');
         response.state.counter.should.be.equal(2);
     });


### PR DESCRIPTION
Signed-off-by: Martin Halford <martin@benext.io>

# Closes #681

### Changes
- Added --data flag and logic to `trigger` command.
- Added/fixed tests for --data flag 
- Added --data flags to `initialise` and `invoke` commands, for consistency.
- Added/fixed tests for --data flag for `initialise` and `invoke` commands too.

### Flags
- Should be backward compatible with previous use cases, as new `--data` flag is optional.
- Have removed mandatory requirement for `--sample` flag and `sample.md`.
- Now checks that either `sample` or `data` exists. At least one must be specified. 
- If neither exists then throws exception.

### Example Usage

```
cicero trigger --template ./hello-world --data ./hello-world/data.json 
cicero initialize  --template ./hello-world --data ./hello-world/data.json 
cicero invoke  --template ./hello-world --clauseName default --params ./hello-world/params.json --state ./hello-world/state.json --data ./hello-world/data.json
```

### Note

Some significant changes to the `validateInvokeArgs`, `validateTriggerArgs` & `validateInitializeArgs` to handle the scenario where either the`--sample` option is provided --OR-- the `--data` option is provided.  