### PR TITLE
fix(server) Replace bitwise OR operator with logical OR for CICERO_PORT setting.

### DIFF
--- a/packages/cicero-server/app.js
+++ b/packages/cicero-server/app.js
@@ -28,7 +28,7 @@ if(!process.env.CICERO_DIR) {
     throw new Error('You must set the CICERO_DIR environment variable.');
 }
 
-const PORT = process.env.CICERO_PORT | 6001;
+const PORT = process.env.CICERO_PORT || 6001;
 
 // to automatically decode JSON POST
 app.use(bodyParser.json());


### PR DESCRIPTION
Signed-off-by: Mehmet Tokgöz <mehmet.tokgoz@hazelcast.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #715<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Bitwise OR operator is replaced by a logical OR operator so that users can set the exact port number they want. 

### Screenshots or Video
Previously, it was running at 14201 when CICERO_PORT was set to 9001. 
<img src="https://i.ibb.co/JzSW4zw/Screen-Shot-2022-09-26-at-13-29-51.png"  border="0">

### Related Issues
- Issue #715

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
