### PR TITLE
fix(core): normalize line endings in template hash calculation

### DIFF
--- a/packages/cicero-core/src/template.js
+++ b/packages/cicero-core/src/template.js
@@ -147,6 +147,19 @@ class Template {
     }
 
     /**
+     * Normalizes line endings to \n to ensure consistent hashing across OS
+     * @param {string} str the string to normalize
+     * @return {string} the normalized string
+     * @private
+     */
+    _normalize(str) {
+        if(str && typeof str === 'string') {
+            return str.replace(/\r/g, '');
+        }
+        return str;
+    }
+
+    /**
      * Gets a content based SHA-256 hash for this template. Hash
      * is based on the metadata for the template plus the contents of
      * all the models and all the script files.
@@ -155,21 +168,36 @@ class Template {
     getHash() {
         const content = {};
         content.metadata = this.getMetadata().toJSON();
+
+        // Normalize README
+        if (content.metadata.README) {
+            content.metadata.README = this._normalize(content.metadata.README);
+        }
+
+        // Normalize Samples
+        if (content.metadata.samples) {
+            Object.keys(content.metadata.samples).forEach(key => {
+                if (typeof content.metadata.samples[key] === 'string') {
+                    content.metadata.samples[key] = this._normalize(content.metadata.samples[key]);
+                }
+            });
+        }
+
         if(this.getTemplate()) {
-            content.grammar = this.getTemplate();
+            content.grammar = this._normalize(this.getTemplate());
         }
         content.models = {};
         content.scripts = {};
 
         let modelFiles = this.getModelManager().getModels();
-        modelFiles.forEach(function (file) {
-            content.models[file.namespace] = file.content;
+        modelFiles.forEach((file) => {
+            content.models[file.namespace] = this._normalize(file.content);
         });
 
         let scriptManager = this.getScriptManager();
         let scriptFiles = scriptManager.getScripts();
-        scriptFiles.forEach(function (file) {
-            content.scripts[file.getIdentifier()] = file.contents;
+        scriptFiles.forEach((file) => {
+            content.scripts[file.getIdentifier()] = this._normalize(file.contents);
         });
 
         const hasher = crypto.createHash('sha256');


### PR DESCRIPTION
This PR fixes a cross-platform compatibility issue where template hash calculations would fail on Windows due to line-ending differences (CRLF vs LF).

### The Issue
The `getHash()` method in `cicero-core` calculates a SHA-256 fingerprint based on the raw string contents of the template (Grammar, Models, Scripts, README, etc.).
- On **Linux/CI**, files typically use `\n` (LF).
- On **Windows**, files often use `\r\n` (CRLF).

Because the hash function did not normalize these strings, the same template would generate different hashes on different operating systems, causing unit tests (`should roundtrip a template`, `should return a SHA-256 hash`) to fail locally for Windows developers.

### The Fix
I added a private `_normalize(str)` helper method to the `Template` class.
- This method aggressively strips Carriage Return (`\r`) characters from strings before they are added to the content object used for hashing.
- It is applied to:
    - Template Grammar
    - Model definitions
    - Script contents
    - Metadata README
    - Metadata Samples

### Verification
Ran `npm test` locally on a Windows environment.
- **Before:** 4 failures in `Template` (hash mismatch).
- **After:** 157 passing tests. All hash-related tests now pass.

### Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (Existing tests now pass).
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`