### PR TITLE
fix(cli): instantiate visitor class to resolve build error

### DIFF
--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -189,10 +189,11 @@ class Commands {
 
         return Commands.loadTemplate(templatePath, options)
             .then((template) => {
-                const visitor = CodeGen.formats[target];
-                if(!visitor) {
+                const VisitorClass = CodeGen.formats[target];
+                if(!VisitorClass) {
                     throw new Error ('Unrecognized code generator: ' + target);
                 }
+                const visitor = new VisitorClass();
                 console.log('generating code...');
                 let parameters = {};
                 parameters.fileWriter = new FileWriter(outputPath);


### PR DESCRIPTION
### Summary
This PR fixes a critical bug in the `cicero-cli compile` command where the build would crash with `TypeError: visitor.visit is not a function`.

The issue stems from a breaking API change in the dependency `@accordproject/concerto-codegen`. The CLI was attempting to use a Class constructor as if it were an instantiated object. This PR updates the logic to correctly instantiate the visitor class before use.

### Technical Details
The `cicero-cli` relies on `concerto-codegen` to retrieve visitor classes for generating output (e.g., Java, Go, JSONSchema).

- **Previous Behavior:** `CodeGen.formats[target]` returned an **instance** of the visitor.
- **Current Behavior:** `CodeGen.formats[target]` returns the **Class constructor** of the visitor.

The existing code in `commands.js` was attempting to call `.visit()` directly on the class constructor, resulting in the runtime error:
`TypeError: visitor.visit is not a function`

### The Fix
Updated `packages/cicero-cli/lib/commands.js` to instantiate the class using the `new` keyword.

**Before:**
```javascript
const visitor = CodeGen.formats[target];
// Error: 'visitor' is a Class, not an object.
template.getModelManager().accept(visitor, parameters);
```
**After**
```javascript
const VisitorClass = CodeGen.formats[target];
// Fix: Instantiate the class first.
const visitor = new VisitorClass();
template.getModelManager().accept(visitor, parameters);
```

**Verification**

Ran `npm test` locally.

    Before: 16 failing tests in @accordproject/cicero-cli.

    After: All tests passed (45 passing)