### PR TITLE
test(cicero-core): 100% coverage for ApArchiveLoader

### DIFF
--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "postlint": "npm run licchk",
     "licchk": "license-check-and-add check -f ./license.config.json",
-    "test:mocha": "mocha --timeout 40000",
+    "test:mocha": "mocha --timeout 40000 --recursive",
     "test:watch": "npm run test:mocha -- --watch",
     "test:windows": "npm run test:mocha",
     "test": "npm run test:mocha",

--- a/packages/cicero-core/test/loaders/aparchiveloader.js
+++ b/packages/cicero-core/test/loaders/aparchiveloader.js
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const ApArchiveLoader = require('../../src/loaders/aparchiveloader');
+const HTTPArchiveLoader = require('../../src/loaders/httparchiveloader');
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.should();
+chai.use(require('chai-as-promised'));
+
+describe('ApArchiveLoader', () => {
+
+    let apLoader;
+    let httpLoadStub;
+
+    beforeEach(() => {
+        apLoader = new ApArchiveLoader();
+        // STUNT DOUBLE: We stub the parent class's load method.
+        // We don't want to make a real HTTP request; we just want to know
+        // what URL the ApLoader TRIED to fetch.
+        httpLoadStub = sinon.stub(HTTPArchiveLoader.prototype, 'load').resolves('ARCHIVE_DATA');
+    });
+
+    afterEach(() => {
+        // Restore the original function after every test so we don't break other tests
+        httpLoadStub.restore();
+    });
+
+    describe('#accepts', () => {
+        it('should accept ap:// URLs', () => {
+            apLoader.accepts('ap://helloworld@0.2.0#hash').should.be.true;
+        });
+
+        it('should reject non-ap URLs', () => {
+            apLoader.accepts('http://google.com').should.be.false;
+            apLoader.accepts('https://templates.accordproject.org').should.be.false;
+        });
+    });
+
+    describe('#load', () => {
+        it('should rewrite the URL and delegate to HTTP load', async () => {
+            const inputUrl = 'ap://helloworld@0.2.0#97886fa';
+            // The logic in source says: substring(5, atIndex) -> "helloworld"
+            // substring(atIndex+1, hashIndex) -> "0.2.0"
+            // Result should be: https://templates.accordproject.org/archives/helloworld@0.2.0.cta
+            const expectedUrl = 'https://templates.accordproject.org/archives/helloworld@0.2.0.cta';
+
+            const result = await apLoader.load(inputUrl, { option: 'test' });
+            result.should.equal('ARCHIVE_DATA');
+            // ASSERT: Did we transform the URL correctly?
+            sinon.assert.calledWith(httpLoadStub, expectedUrl, { option: 'test' });
+        });
+
+        it('should throw error if @ is missing', async () => {
+            const inputUrl = 'ap://helloworld#hash';
+            (() => {
+                apLoader.load(inputUrl, {});
+            }).should.throw(/Invalid template specifier/);
+        });
+
+        it('should throw error if # is missing', async () => {
+            const inputUrl = 'ap://helloworld@0.2.0';
+            (() => {
+                apLoader.load(inputUrl, {});
+            }).should.throw(/Invalid template specifier/);
+        });
+    });
+});


### PR DESCRIPTION
### Description
This PR addresses the low test coverage for `ApArchiveLoader` in `cicero-core`.

Previously, `aparchiveloader.js` had **~16% coverage**. The critical logic—specifically the validation of `ap://` protocol requirements and the rewriting of URLs before delegation—was untested, and there was no script to test it.

**Changes:**
1. **Added `packages/cicero-core/test/loaders/aparchiveloader.js`**:
   - Implemented a unit test suite using `Sinon` to mock the parent `HTTPArchiveLoader`.
   - This approach verifies the **logic** of the loader (URL rewriting and error handling) in isolation, ensuring tests are fast and do not rely on external network availability or the status of the Accord Project website.
   
2. **Updated `packages/cicero-core/package.json`**:
   - Re-applied the `--recursive` flag for the Mocha test runner to ensure tests in subdirectories (like the new loader tests) are correctly discovered and executed.

### Results
Coverage for `aparchiveloader.js` is now **100%**.

**Before:**
```text
aparchiveloader.js  |  16.66 | 0 | 0 | 16.66
```

**After**
```text
aparchiveloader.js  | 100 | 100 | 100 | 100
```
<img width="1920" height="1080" alt="Screenshot1" src="https://github.com/user-attachments/assets/323b9cd8-688c-4de6-8b05-b9836759fbda" />
