### PR TITLE
feat(cicero-core): add timeout option to HTTPArchiveLoader

### DIFF
--- a/packages/cicero-core/src/loaders/httparchiveloader.js
+++ b/packages/cicero-core/src/loaders/httparchiveloader.js
@@ -57,7 +57,8 @@ class HTTPArchiveLoader {
         request.url = requestUrl;
         request.method = 'get';
         request.responseType = 'arraybuffer'; // Necessary for binary archives
-        request.timeout = 5000;
+        // Use the user's timeout, or default to 5000ms
+        request.timeout = options.timeout || 5000;
         if (options.httpAuthHeader) {
             request.headers = {
                 authorization: options.httpAuthHeader,

--- a/packages/cicero-core/test/httparchiveloader.js
+++ b/packages/cicero-core/test/httparchiveloader.js
@@ -77,5 +77,23 @@ describe('HTTPArchiveLoader', () => {
 
             mock.stop('axios');
         });
+
+        it('should load an archive with a custom timeout', async function() {
+            mock('axios', (params) => {
+                axiosParams = params;
+                return Promise.resolve({ data: 'data' });
+            });
+            HTTPArchiveLoader = mock.reRequire('../src/loaders/httparchiveloader');
+            const loader = new HTTPArchiveLoader();
+
+            // ACT: We ask for a 10-second timeout (10000ms)
+            await loader.load('https://templates.accordproject.org/archives/ip-payment@0.13.0.cta', { timeout: 10000 });
+
+            // ASSERT: We check if Axios actually received that number
+            expect(axiosParams.timeout).to.equal(10000);
+
+            mock.stop('axios');
+        });
+
     });
 });


### PR DESCRIPTION
### Description
This PR adds a configurable `timeout` option to `HTTPArchiveLoader`, allowing developers to handle slow network conditions when loading templates.

Previously, the timeout was hardcoded to **5000ms**, which caused failures on slower connections or large files. This change allows users to pass a custom `timeout` via the options object, defaulting to 5000ms if not provided.

### Usage Example
Developers can now specify a timeout (in milliseconds) when loading an archive:

```javascript
const loader = new HTTPArchiveLoader();

// Old behavior (defaults to 5000ms)
await loader.load('[http://template.url](http://template.url)');

// New behavior (waits 10 seconds)
await loader.load('[http://template.url](http://template.url)', { timeout: 10000 });
```
**Changes:**
1. **Refactor**: Updated `httparchiveloader.js` to accept `options.timeout`.
2. **Test**: Added a unit test verifying that the custom timeout value is correctly passed to the `axios` request configuration.
3. **Coverage**: Improved branch coverage for `httparchiveloader.js` by exercising the custom options path.

### Testing
- [x] Verified that existing tests pass (Default path).
- [x] Verified that the new test case passes (Custom path).

**Coverage Improvement:**
Branch coverage for `httparchiveloader.js` increased from **60%** to **66.66%**.
