### PR TITLE
test(cicero-core): 100% coverage for LogicManager

### DIFF
--- a/packages/cicero-core/test/logicmanager.js
+++ b/packages/cicero-core/test/logicmanager.js
@@ -24,7 +24,7 @@ chai.use(require('chai-as-promised'));
 
 const fs = require('fs');
 
-const ctoSample = fs.readFileSync('./test/data/test.cto','utf8');
+const ctoSample = fs.readFileSync('./test/data/test.cto', 'utf8');
 
 describe('LogicManager', () => {
     describe('#constructors-accessors', () => {
@@ -39,14 +39,18 @@ describe('LogicManager', () => {
 
         it('should load a model to the model manager', () => {
             const logicManager = new LogicManager('es6');
-            const modelFile = logicManager.getModelManager().addCTOModel(ctoSample,'test.cto');
+            const modelFile = logicManager.getModelManager().addCTOModel(ctoSample, 'test.cto');
             modelFile.should.not.be.null;
         });
 
         it('should load a model to the model manager (bulk)', () => {
             const logicManager = new LogicManager('es6');
-            const modelFiles = logicManager.getModelManager().addModelFiles([ctoSample],['test.cto']);
+            const modelFiles = logicManager.getModelManager().addModelFiles([ctoSample], ['test.cto']);
             modelFiles.should.not.be.null;
+        });
+
+        it('should throw an error for unsupported language', () => {
+            return (() => new LogicManager('invalid-language')).should.throw('Unknown language invalid-language');
         });
     });
 });


### PR DESCRIPTION
# Closes #859 

Adds a unit test to cover the error branch in the LogicManager constructor when an unsupported language is provided.

### Changes
- Added a test case to verify that the LogicManager constructor throws an error when an invalid language is passed.
- Improved overall test coverage from 94.44% to 100%.

### Author Checklist
- [ x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ x] Vital features and changes captured in unit and/or integration tests
- [ x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ x] Merging to `master` from `fork:branchname`
