### PR TITLE
docs: update documentation link to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can browse the library of Open Source Cicero contract and clause templates a
 
 Cicero is an Open Source implementation of the [Accord Project Template Specification][apspec]. It defines the structure of natural language templates, bound to a data model, that can be executed using request/response JSON messages.
 
-You can read the latest user documentation here: http://docs.accordproject.org.
+You can read the latest user documentation here: https://docs.accordproject.org.
 
 ## Clause Templates
 


### PR DESCRIPTION

# Closes #N/A

### Summary
This PR updates the documentation link in the README to use HTTPS instead of HTTP.

Using HTTPS improves security and follows modern best practices for linking to external documentation.

### Changes
- Updated documentation link from `http://docs.accordproject.org` to `https://docs.accordproject.org` in the README.
- Minor documentation improvement with no functional changes.

### Flags
- Documentation-only change
- No impact on functionality or tests

### Screenshots or Video
Not applicable.

### Related Issues
None

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
