### PR TITLE
fix: widen Concerto version constraints and replace wildcard import for v4 compatibility

### DIFF
--- a/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.contract.cto
+++ b/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.contract.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.contract
 

--- a/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-cli/test/data/helloemit/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.contract
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.runtime
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-cli/test/data/helloworldstate/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-cli/test/data/latedeliveryandpenalty/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-cli/test/data/latedeliveryandpenalty/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-cli/test/data/signedArchive/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-cli/test/data/signedArchiveFail/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-cli/test/data/signedArchiveFail/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-cli/test/data/signedArchiveFail/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-cli/test/data/signedArchiveFail/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/src/external/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/src/external/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/src/external/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/src/external/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/src/external/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-core/src/external/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-core/src/external/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-core/src/external/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-core/test/data/bad-copyright-license/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/bad-copyright-license/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/bad-copyright-license/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/bad-copyright-license/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/bad-property/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/bad-property/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/bad-property/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/bad-property/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.party@0.2.0.cto
+++ b/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.party@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.party@0.2.0
 

--- a/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-core/test/data/copyright-license/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-core/test/data/fixed-interests/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-core/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/helloworldstate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/helloworldstate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/latedeliveryandpenalty-cr/model/@models.accordproject.org.accordproject.runtime.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty-cr/model/@models.accordproject.org.accordproject.runtime.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.runtime@1.0.0
 

--- a/packages/cicero-core/test/data/latedeliveryandpenalty_js/model/@models.accordproject.org.accordproject.runtime.cto
+++ b/packages/cicero-core/test/data/latedeliveryandpenalty_js/model/@models.accordproject.org.accordproject.runtime.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.runtime@1.0.0
 

--- a/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.money@0.3.0.cto
+++ b/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.money@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.money@0.3.0
 

--- a/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.time@0.3.0.cto
+++ b/packages/cicero-core/test/data/logo@0.0.1/model/@models.accordproject.org.time@0.3.0.cto
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.time@0.3.0
 

--- a/packages/cicero-core/test/data/logo@0.0.1/model/model.cto
+++ b/packages/cicero-core/test/data/logo@0.0.1/model/model.cto
@@ -1,6 +1,6 @@
 namespace logo.support.TemplateLogoClause@1.0.0
 
-import org.accordproject.contract.* from https://models.accordproject.org/accordproject/contract.cto
+import org.accordproject.contract.Clause from https://models.accordproject.org/accordproject/contract.cto
 
 /**
  * The template model

--- a/packages/cicero-core/test/data/no-logic/model/@models.accordproject.org.accordproject.runtime.cto
+++ b/packages/cicero-core/test/data/no-logic/model/@models.accordproject.org.accordproject.runtime.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.runtime@1.0.0
 

--- a/packages/cicero-core/test/data/template-decorator/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/template-decorator/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/text-only/model/@models.accordproject.org.accordproject.runtime.cto
+++ b/packages/cicero-core/test/data/text-only/model/@models.accordproject.org.accordproject.runtime.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version ">= 1.0.0"
+concerto version ">=1.0.0"
 
 namespace org.accordproject.runtime@1.0.0
 

--- a/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperDate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperDate/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperDate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperDate/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 

--- a/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperSign/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
+++ b/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperSign/model/@models.accordproject.org.accordproject.contract@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.contract@0.2.0
 

--- a/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperSign/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
+++ b/packages/cicero-core/test/data/verifying-template-signature/helloworldstateTamperSign/model/@models.accordproject.org.accordproject.runtime@0.2.0.cto
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-concerto version "^3.0.0"
+concerto version ">=3.0.0"
 
 namespace org.accordproject.runtime@0.2.0
 


### PR DESCRIPTION
## Summary

- Widen `concerto version` declarations in 101 `.cto` files from `"^3.0.0"` → `">=3.0.0"` and `">= 1.0.0"` → `">=1.0.0"`, so they satisfy both Concerto v3 (current) and v4 (upcoming)
- Replace wildcard import `org.accordproject.contract.*` with explicit `org.accordproject.contract.Clause` in `test/data/logo@0.0.1/model/model.cto`, as Concerto v4's parser rejects `import ... *` syntax

Closes #886

## Test plan

- [x] Verified all existing tests pass with current Concerto v3 (`179 passing, 0 failing`)
- [x] Verified these changes resolve the version-check failures when testing against Concerto v4 main branch