### PR TITLE
fix(cicero-core): add browser-compatible bundle

### DIFF
--- a/packages/cicero-core/package.json
+++ b/packages/cicero-core/package.json
@@ -15,6 +15,10 @@
     "types"
   ],
   "main": "dist/cicero-core.js",
+  "browser": {
+    "fs": false,
+    "path": false
+  },
   "typings": "types/index.d.ts",
   "scripts": {
     "webpack": "webpack --config webpack.config.js --mode production",

--- a/packages/cicero-core/src/templateloader.js
+++ b/packages/cicero-core/src/templateloader.js
@@ -14,19 +14,11 @@
 
 'use strict';
 
-const fs = require('fs');
-const fsPath = require('path');
 const slash = require('slash');
 const JSZip = require('jszip');
 // const xregexp = require('xregexp');
 // const languageTagRegex = require('ietf-language-tag-regex');
-const promisify = require('util').promisify;
 const Logger = require('@accordproject/concerto-util').Logger;
-
-const DefaultArchiveLoader = require('./loaders/defaultarchiveloader');
-
-const readdir = fs.readdir ? promisify(fs.readdir) : undefined;
-const stat = fs.stat ? promisify(fs.stat) : undefined;
 
 const ENCODING = 'utf8';
 
@@ -128,6 +120,7 @@ class TemplateLoader {
      * @return {Promise} a Promise to the template
      */
     static async fromUrl(Template, url, options) {
+        const DefaultArchiveLoader = require('./loaders/defaultarchiveloader');
         const loader = new DefaultArchiveLoader();
         const buffer = await loader.load(url, options);
         return TemplateLoader.fromArchive(Template, buffer, options);
@@ -145,6 +138,8 @@ class TemplateLoader {
      */
     static async fromDirectory(Template, path, options = {}) {
         const method = 'fromDirectory';
+        const fs = require('fs');
+        const fsPath = require('path');
 
         // grab the README.md
         const readmeContents = await TemplateLoader.loadFileContents(path, 'README.md');
@@ -332,6 +327,8 @@ class TemplateLoader {
      * required is false
      */
     static async loadFileContents(path, fileName, json = false, required = false) {
+        const fs = require('fs');
+        const fsPath = require('path');
 
         Logger.debug('loadFileContents', 'Loading ' + fileName);
         const filePath = fsPath.resolve(path, fileName);
@@ -364,6 +361,8 @@ class TemplateLoader {
      * it does not exist and required is false
      */
     static async loadFileBuffer(path, fileName, required = false) {
+        const fs = require('fs');
+        const fsPath = require('path');
 
         Logger.debug('loadFileBuffer', 'Loading ' + fileName);
         const filePath = fsPath.resolve(path, fileName);
@@ -388,6 +387,11 @@ class TemplateLoader {
      * @return {Promise<object[]>} a promise to an array of objects with the name and contents of the files
      */
     static async loadFilesContents(path, regex) {
+        const fs = require('fs');
+        const fsPath = require('path');
+        const promisify = require('util').promisify;
+        const readdir = promisify(fs.readdir);
+        const stat = promisify(fs.stat);
 
         Logger.debug('loadFilesContents', 'Loading ' + path);
         const subdirs = await readdir(path);

--- a/packages/cicero-core/src/templatesaver.js
+++ b/packages/cicero-core/src/templatesaver.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const JSZip = require('jszip');
-const fsPath = require('path');
 
 /**
  * A utility to persist templates to data sources.
@@ -107,7 +106,7 @@ class TemplateSaver {
         const scriptFiles = template.getScriptManager().getScriptsForTarget(language);
         scriptFiles.forEach(function (file) {
             let fileIdentifier = file.getIdentifier();
-            let fileName = fsPath.basename(fileIdentifier);
+            let fileName = fileIdentifier.split('/').pop() || fileIdentifier;
             zip.file('logic/' + fileName, file.contents, options);
         });
 

--- a/packages/cicero-core/src/templatesaver.js
+++ b/packages/cicero-core/src/templatesaver.js
@@ -106,7 +106,7 @@ class TemplateSaver {
         const scriptFiles = template.getScriptManager().getScriptsForTarget(language);
         scriptFiles.forEach(function (file) {
             let fileIdentifier = file.getIdentifier();
-            let fileName = fileIdentifier.split('/').pop() || fileIdentifier;
+            let fileName = fileIdentifier.split(/[\\/]/).pop() || fileIdentifier;
             zip.file('logic/' + fileName, file.contents, options);
         });
 

--- a/packages/cicero-core/webpack.config.js
+++ b/packages/cicero-core/webpack.config.js
@@ -21,26 +21,19 @@ const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 const packageJson = require("./package.json");
 
 module.exports = {
-  target: 'node',
+  target: 'web',
   entry: path.resolve(__dirname, "index.js"),
   output: {
     clean: true,
-    // globalObject: 'self',
+    globalObject: 'this',
     path: path.resolve(__dirname, "dist"),
     filename: "cicero-core.js",
     library: {
-      type: "commonjs",
+      type: "umd",
     },
   },
-  // externals: {
-  //   'node-forge': false,
-  // },
   // Enable sourcemaps for debugging webpack's output.
   devtool: "source-map",
-  resolve: {
-    // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
-  },
   module: {
     rules: [
       // All files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'.
@@ -74,6 +67,8 @@ module.exports = {
     new NodePolyfillPlugin(),
   ],
   resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
     fallback: {
       // Webpack 5 no longer polyfills Node.js core modules automatically.
       // see https://webpack.js.org/configuration/resolve/#resolvefallback


### PR DESCRIPTION
# Closes #880 #883 

This PR makes cicero-core's webpack bundle browser-compatible so that `TemplateLoader.fromArchive()` and `TemplateSaver.toArchive()` can be used in browser environments without `fs`/`path` resolution errors.

### Changes

- Move Node.js-only requires (`fs`, `path`, `util.promisify`, `DefaultArchiveLoader`) from module scope into the methods that actually use them (`fromDirectory`, `fromUrl`, `loadFileContents`, `loadFileBuffer`, `loadFilesContents`) in `templateloader.js`
- Remove top-level `require('path')` from `templatesaver.js` and replace `fsPath.basename()` with `fileIdentifier.split('/').pop() || fileIdentifier` for browser-safe filename extraction
- Change webpack `target` from `'node'` to `'web'` so `resolve.fallback` is respected
- Fix duplicate `resolve` key in `webpack.config.js` (second silently overwrote the first) by merging `extensions` into the single `resolve` block
- Change webpack `library.type` from `'commonjs'` to `'umd'` with `globalObject: 'this'` for cross-environment compatibility
- Remove deprecated empty string `""` from webpack `resolve.extensions` (Webpack 4 convention, invalid in Webpack 5)
- Add `"browser"` field to `package.json` mapping `fs` and `path` to `false` for downstream bundlers

### Flags

- The archive methods (`fromArchive`, `toArchive`) were already browser-safe internally ( as they use JSZip and operate on buffers), the incompatibility came from transitive top-level `require('fs')` / `require('path')` being pulled into the module graph
- UMD output is backward-compatible with CommonJS consumers,  existing Node.js usage is unaffected
- All 183 existing tests pass unchanged; no new dependencies added
- Bundle size is 3.4MB (unchanged from before) , the size warnings are pre-existing

### Screenshots or Video

N/A — this is a bundling/build change with no UI impact.

### Related Issues

- Issue #880 #883
- Pull Request [accordproject/template-playground#562](https://github.com/accordproject/template-playground/pull/562)

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `Shubh-Raj:fix/browser-compatible-bundle`
