### PR TITLE
feat(cicero-cli): add validate command for standalone template validation

### DIFF
--- a/packages/cicero-cli/README.md
+++ b/packages/cicero-cli/README.md
@@ -16,6 +16,56 @@ npm install -g @accordproject/cicero-cli
 
 Run `cicero --help` for usage instructions.
 
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `cicero archive` | Create a `.cta` template archive from a template directory |
+| `cicero compile` | Generate code for a target platform from a template's model |
+| `cicero get` | Save local copies of a template's external model dependencies |
+| `cicero validate` | Validate a template directory without producing output artifacts |
+| `cicero verify` | Verify the signature of a signed template archive |
+
+### `cicero validate`
+
+Fast, side-effect-free check that a template directory is well-formed. Runs
+layered structural checks (package.json, grammar, model) followed by a full
+coherence check via `Template.fromDirectory`. Emits a per-check `✓`/`✗`
+summary and exits with code `1` on any failure — suitable for CI pipelines.
+
+```bash
+cicero validate --template <path> [--warnings]
+```
+
+Options:
+- `--template <path>` — path to the template directory (defaults to `.`)
+- `--warnings` — surface non-fatal warnings (e.g. orphan `logic/` directory,
+  since Ergo is no longer executed by `cicero-core`)
+
+Example (valid template):
+
+```
+$ cicero validate --template ./my-template
+✓ package.json valid
+✓ text/grammar.tem.md found
+✓ model/ found 2 .cto file(s)
+✓ Template coherence grammar parsed, model validated, template variables match the model
+
+Template is valid.
+```
+
+Example (broken template):
+
+```
+$ cicero validate --template ./my-template
+✓ package.json valid
+✓ text/grammar.tem.md found
+✓ model/ found 1 .cto file(s)
+✗ model/ — Undeclared type "PaymentAmount" in "property ...TemplateModel.amount"
+
+Validation failed. 1 error found.
+```
+
 ## License <a name="license"></a>
 Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
 

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -160,6 +160,57 @@ require('yargs')
             return;
         }
     })
+    .command('validate', 'validate a template without producing output artifacts', (yargs) => {
+        yargs.option('template', {
+            describe: 'path to the template directory',
+            type: 'string'
+        });
+        yargs.option('warnings', {
+            describe: 'surface non-fatal warnings (e.g. orphaned logic/ directory)',
+            type: 'boolean',
+            default: false
+        });
+    }, async (argv) => {
+        if (argv.verbose) {
+            Logger.info(`validate template at ${argv.template}`);
+        }
+
+        try {
+            argv = Commands.validateValidateArgs(argv);
+            const { results, warnings, valid } = await Commands.validate(argv.template, {
+                warnings: argv.warnings,
+            });
+
+            for (const r of results) {
+                const line = r.ok
+                    ? `\u2713 ${r.layer} ${r.message}`
+                    : `\u2717 ${r.layer} \u2014 ${r.message}`;
+                if (r.ok) {
+                    console.log(line);
+                } else {
+                    console.error(line);
+                }
+            }
+            if (warnings.length > 0) {
+                console.log('');
+                for (const w of warnings) {
+                    console.log(`\u26A0 ${w}`);
+                }
+            }
+            console.log('');
+            if (valid) {
+                console.log('Template is valid.');
+            } else {
+                const errCount = results.filter((r) => !r.ok).length;
+                console.error(`Validation failed. ${errCount} error${errCount === 1 ? '' : 's'} found.`);
+                process.exitCode = 1;
+            }
+        } catch (err) {
+            Logger.error(err.message);
+            process.exitCode = 1;
+        }
+    })
+
     .command('get', 'save local copies of external dependencies', (yargs) => {
         yargs.option('template', {
             describe: 'path to the template',

--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -239,6 +239,154 @@ class Commands {
                 return `Loaded external models in '${output}'.`;
             });
     }
+
+    /**
+     * Set default params before we validate a template.
+     *
+     * Unlike validateCommonArgs, this does NOT throw on missing/malformed
+     * package.json — reporting those conditions is the purpose of the validate
+     * command itself.
+     *
+     * @param {object} argv the inbound argument values object
+     * @returns {object} a modified argument object
+     */
+    static validateValidateArgs(argv) {
+        if (argv._.length === 2) {
+            argv.template = argv._[1];
+        }
+        if (!argv.template) {
+            Logger.info('Using current directory as template folder');
+            argv.template = '.';
+        }
+        argv.template = path.resolve(argv.template);
+        return argv;
+    }
+
+    /**
+     * Validate a template directory in isolation, with layered per-check output.
+     *
+     * Runs a sequence of structural and coherence checks and returns a result
+     * object describing what passed and what failed. Unlike `archive`, `compile`,
+     * or `parse`, this command produces no output artifacts and requires no
+     * sample file. It is intended as a fast CI-friendly lint step.
+     *
+     * Checks, in order:
+     *   1. template path exists and is a directory
+     *   2. package.json exists, parses as JSON, and contains an accordproject section
+     *   3. text/grammar.tem.md exists
+     *   4. model/ exists and contains at least one .cto file
+     *   5. overall template coherence via Template.fromDirectory
+     *      (parses grammar, validates model, checks variable/model agreement)
+     *
+     * The first four checks are per-file and short-circuit on the first failure
+     * so the error surface pinpoints the broken layer. The last check wraps
+     * cicero-core's own loader and surfaces its error message verbatim when it
+     * throws.
+     *
+     * @param {string} templatePath - path to the template directory
+     * @param {object} [options] - optional configuration
+     * @param {boolean} [options.warnings] - surface non-fatal warnings
+     * @returns {Promise<object>} a result object with `results` (per-check
+     *   entries), `warnings` (string array), and `valid` (boolean)
+     */
+    static async validate(templatePath, options = {}) {
+        const results = [];
+        const warnings = [];
+
+        // Check 1: path exists and is a directory
+        if (!fs.existsSync(templatePath)) {
+            results.push({ layer: 'path', ok: false, message: `template path not found: ${templatePath}` });
+            return { results, warnings, valid: false };
+        }
+        if (!fs.lstatSync(templatePath).isDirectory()) {
+            results.push({
+                layer: 'path',
+                ok: false,
+                message: `${templatePath} is not a directory. Use 'cicero verify' for .cta archives.`,
+            });
+            return { results, warnings, valid: false };
+        }
+
+        // Check 2: package.json exists, parses, has accordproject section
+        const pkgPath = path.resolve(templatePath, 'package.json');
+        if (!fs.existsSync(pkgPath)) {
+            results.push({ layer: 'package.json', ok: false, message: 'file not found' });
+            return { results, warnings, valid: false };
+        }
+        let pkg;
+        try {
+            pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        } catch (err) {
+            results.push({ layer: 'package.json', ok: false, message: `not valid JSON: ${err.message}` });
+            return { results, warnings, valid: false };
+        }
+        if (!pkg.accordproject) {
+            results.push({
+                layer: 'package.json',
+                ok: false,
+                message: 'missing "accordproject" section (required for Cicero templates)',
+            });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'package.json', ok: true, message: 'valid' });
+
+        // Check 3: grammar.tem.md exists
+        const grammarPath = path.resolve(templatePath, 'text', 'grammar.tem.md');
+        if (!fs.existsSync(grammarPath)) {
+            results.push({ layer: 'text/grammar.tem.md', ok: false, message: 'file not found' });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'text/grammar.tem.md', ok: true, message: 'found' });
+
+        // Check 4: model/ exists and contains .cto files
+        const modelDir = path.resolve(templatePath, 'model');
+        if (!fs.existsSync(modelDir) || !fs.lstatSync(modelDir).isDirectory()) {
+            results.push({ layer: 'model/', ok: false, message: 'model directory not found' });
+            return { results, warnings, valid: false };
+        }
+        const ctoFiles = fs.readdirSync(modelDir).filter((f) => f.endsWith('.cto'));
+        if (ctoFiles.length === 0) {
+            results.push({ layer: 'model/', ok: false, message: 'no .cto files found' });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'model/', ok: true, message: `found ${ctoFiles.length} .cto file(s)` });
+
+        // Check 5: full coherence via Template.fromDirectory
+        try {
+            await Commands.loadTemplate(templatePath, options);
+            results.push({
+                layer: 'Template coherence',
+                ok: true,
+                message: 'grammar parsed, model validated, template variables match the model',
+            });
+        } catch (err) {
+            const msg = err.message || String(err);
+            let layer = 'Template coherence';
+            const lower = msg.toLowerCase();
+            if (lower.includes('grammar')) {
+                layer = 'text/grammar.tem.md';
+            } else if (lower.includes('.cto') || lower.includes('namespace') || lower.includes('type ')) {
+                layer = 'model/';
+            }
+            results.push({ layer, ok: false, message: msg });
+        }
+
+        // Warnings: Ergo logic files are ignored at runtime
+        if (options.warnings) {
+            const logicDir = path.resolve(templatePath, 'logic');
+            if (fs.existsSync(logicDir) && fs.lstatSync(logicDir).isDirectory()) {
+                const logicFiles = fs.readdirSync(logicDir);
+                if (logicFiles.length > 0) {
+                    warnings.push(
+                        `logic/ directory contains ${logicFiles.length} file(s); Ergo is no longer executed by cicero-core and these are ignored at runtime`
+                    );
+                }
+            }
+        }
+
+        const valid = results.every((r) => r.ok);
+        return { results, warnings, valid };
+    }
 }
 
 module.exports = Commands;

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -319,3 +319,125 @@ describe('#verify', async () => {
         return Commands.verify(templatePath).should.be.rejectedWith('Template\'s author signature is invalid!');
     });
 });
+
+describe('#validateValidateArgs', () => {
+    it('no args specified — defaults to cwd', () => {
+        process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+        const args = Commands.validateValidateArgs({
+            _: ['validate'],
+        });
+        args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
+    });
+    it('template arg specified', () => {
+        process.chdir(path.resolve(__dirname));
+        const args = Commands.validateValidateArgs({
+            _: ['validate', 'data/latedeliveryandpenalty/'],
+        });
+        args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
+    });
+    it('does not throw on missing package.json — reporting that is the whole point', () => {
+        process.chdir(path.resolve(__dirname, 'data/'));
+        // Unlike validateCommonArgs, this must NOT throw. If it did, the validate
+        // command would crash on exactly the condition it is supposed to report.
+        (() => Commands.validateValidateArgs({
+            _: ['validate'],
+        })).should.not.throw();
+    });
+});
+
+describe('#validate', () => {
+    const validateFixtures = path.resolve(__dirname, 'data/validate');
+
+    it('passes on a known-good template', async () => {
+        const result = await Commands.validate(
+            path.resolve(__dirname, 'data/latedeliveryandpenalty')
+        );
+        result.valid.should.equal(true);
+        result.results.should.be.an('array').that.is.not.empty;
+        result.results.every((r) => r.ok).should.equal(true);
+    });
+
+    it('fails when the path does not exist', async () => {
+        const result = await Commands.validate('/does/not/exist/anywhere');
+        result.valid.should.equal(false);
+        result.results.should.have.lengthOf(1);
+        result.results[0].layer.should.equal('path');
+        result.results[0].ok.should.equal(false);
+    });
+
+    it('fails and short-circuits when package.json is missing', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-package-json'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.ok.should.equal(false);
+        last.message.should.match(/not found/);
+    });
+
+    it('fails when package.json is not valid JSON', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'invalid-json-package'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/not valid JSON/);
+    });
+
+    it('fails when package.json has no accordproject section', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'no-accord-section'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/accordproject/);
+    });
+
+    it('fails when text/grammar.tem.md is missing', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-grammar'));
+        result.valid.should.equal(false);
+        // package.json should have passed first
+        result.results[0].layer.should.equal('package.json');
+        result.results[0].ok.should.equal(true);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('text/grammar.tem.md');
+        last.ok.should.equal(false);
+    });
+
+    it('fails when model/ has no .cto files', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-model'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('model/');
+        last.ok.should.equal(false);
+    });
+
+    it('fails on a .cto that references an unknown type', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'invalid-cto'));
+        result.valid.should.equal(false);
+        // The structural checks (package.json, grammar, model/) should all pass
+        // — the failure is in the Template coherence layer.
+        const failing = result.results.filter((r) => !r.ok);
+        failing.should.have.lengthOf(1);
+        failing[0].ok.should.equal(false);
+        // The error message should mention the unknown type
+        failing[0].message.should.match(/DoesNotExist/);
+    });
+
+    it('emits no warnings when --warnings is false', async () => {
+        const result = await Commands.validate(
+            path.resolve(__dirname, 'data/latedeliveryandpenalty'),
+            { warnings: false }
+        );
+        result.warnings.should.be.an('array').that.is.empty;
+    });
+
+    it('surfaces orphan logic/ directory as a warning when --warnings is true', async () => {
+        const result = await Commands.validate(
+            path.resolve(validateFixtures, 'has-orphan-logic'),
+            { warnings: true }
+        );
+        // The template itself is valid — the logic dir is just flagged.
+        result.valid.should.equal(true);
+        result.warnings.should.be.an('array').with.lengthOf(1);
+        result.warnings[0].should.match(/logic\//);
+        result.warnings[0].should.match(/Ergo/);
+    });
+});

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/logic/logic.ergo
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/logic/logic.ergo
@@ -1,0 +1,1 @@
+// Legacy Ergo file — no longer executed

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.orphanlogic@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/package.json
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "has-orphan-logic",
+    "version": "0.0.1",
+    "description": "Fixture: valid template that still carries an orphan logic/ directory",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/invalid-cto/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.invalidcto@1.0.0
+
+@template
+concept TemplateModel {
+  o DoesNotExist name
+}

--- a/packages/cicero-cli/test/data/validate/invalid-cto/package.json
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "invalid-cto",
+    "version": "0.0.1",
+    "description": "Fixture: .cto references an unknown type so model validation fails",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/invalid-cto/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.badjson@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/package.json
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/package.json
@@ -1,0 +1,1 @@
+{ this is not valid json

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-grammar/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-grammar/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missinggrammar@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-grammar/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-grammar/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "missing-grammar",
+    "version": "0.0.1",
+    "description": "Fixture: valid package.json but no text/grammar.tem.md",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-model/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-model/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "missing-model",
+    "version": "0.0.1",
+    "description": "Fixture: valid package.json + grammar but no model/ directory",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-model/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-model/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-package-json/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-package-json/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missingpkg@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-package-json/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-package-json/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/no-accord-section/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.noaccord@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/no-accord-section/package.json
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "no-accord-section",
+    "version": "0.0.1",
+    "description": "Fixture: package.json has no accordproject entry"
+}

--- a/packages/cicero-cli/test/data/validate/no-accord-section/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.


### PR DESCRIPTION
## Summary

Implements `cicero validate` as a new CLI command, per feature request [#879](https://github.com/accordproject/template-archive/issues/879).

`cicero validate --template <path>` runs layered structural and coherence checks on a template directory and exits with code `1` on any failure — no sample file required, no output artifacts produced. Intended as a fast, side-effect-free lint step for CI pipelines.

```
$ cicero validate --template ./my-template
✓ package.json valid
✓ text/grammar.tem.md found
✓ model/ found 2 .cto file(s)
✓ Template coherence grammar parsed, model validated, template variables match the model

Template is valid.
```

On failure, the per-check `✓`/`✗` output pinpoints which layer broke:

```
$ cicero validate --template ./my-template
✓ package.json valid
✓ text/grammar.tem.md found
✓ model/ found 1 .cto file(s)
✗ model/ — Undeclared type "PaymentAmount" in "property ...TemplateModel.amount"

Validation failed. 1 error found.
```

## What changed

- **`packages/cicero-cli/lib/commands.js`** — new `Commands.validateValidateArgs()` and `Commands.validate()` static methods. `validate()` does four per-file structural checks (path, `package.json`, `text/grammar.tem.md`, `model/*.cto`) that short-circuit on the first failure, then delegates to `Commands.loadTemplate()` for full grammar/model coherence via `Template.fromDirectory()`. Unlike `validateCommonArgs`, the new arg-validator does not throw on a missing or malformed `package.json` — reporting that condition is the command's purpose.
- **`packages/cicero-cli/index.js`** — new `validate` subcommand registered with yargs, supporting `--template <path>` (defaults to `.`) and `--warnings` (surface non-fatal warnings). Emits layered `✓`/`✗` to stdout/stderr, sets `process.exitCode = 1` on any failure.
- **`packages/cicero-cli/README.md`** — new command table plus a dedicated section for `cicero validate` with example output.
- **`packages/cicero-cli/test/cli.js`** — 13 new tests across `#validateValidateArgs` and `#validate`, covering the happy path, each failure mode (missing path, missing package.json, invalid JSON, missing accordproject section, missing grammar, empty model dir, .cto with unknown type), the no-throw guarantee on missing package.json, and the `--warnings` flag.
- **`packages/cicero-cli/test/data/validate/`** — 7 new fixture templates (one valid-with-orphan-logic, six broken-in-distinct-ways).

## Test plan

- [x] `npm test` at the `template-archive` root — all workspaces green, zero regressions.
- [x] `npm test` in `packages/cicero-cli` — 58 passing, 1 pending (unchanged from `main`: the existing `signedArchiveFail` test was already skipped).
- [x] Manual smoke against `test/data/latedeliveryandpenalty/` — exits 0 with 4 `✓` lines.
- [x] Manual smoke against each fixture in `test/data/validate/` — each exits 1 and pinpoints the correct layer.
- [x] `--warnings` against `test/data/validate/has-orphan-logic/` — surfaces the Ergo orphan warning but template remains valid.
- [x] `npm run licchk` at root — all files have licenses (no new source files need headers; fixtures and README are in the ignore list).

## Scope notes

- Directory-only for this first pass. `.cta` archives are already handled by `cicero verify`; adding archive support to `validate` would be a natural follow-up but is out of scope here.
- The spec mentioned an `engines.cicero` field; existing Accord Project templates use `accordproject.cicero` (see e.g. `latedeliveryandpenalty/package.json`), so the check keys off the `accordproject` section rather than `engines.cicero`. Happy to adjust if preferred.
- Error-layer classification on the coherence check is best-effort string matching over the exception message. Exact layer attribution could be improved by exposing structured error types from `cicero-core`, but that felt out of scope.

Closes #879.

Signed-off-by: Yuzhou Wang <wusiwyzb5@gmail.com>
