### PR TITLE
fix(ci): add permissions for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC / npmjs publish
+  contents: write
+  pull-requests: write
 
 jobs:
   publish:
@@ -44,7 +46,7 @@ jobs:
           npm publish --workspaces --access public --provenance ${{ steps.tag.outputs.tag }} 2>&1
 
       - name: Create PR to increment version
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           commit-message: 'chore(actions): publish ${{ github.event.release.tag_name }} to npm'


### PR DESCRIPTION
## Summary

- Adds `contents: write` and `pull-requests: write` permissions to the publish workflow
- Upgrades `peter-evans/create-pull-request` from v7 to v8

This fixes the 403 permission denied error when the workflow tries to push the version bump PR branch.

## Root Cause

The workflow was missing the required permissions for github-actions[bot] to push branches and create PRs.

## Related

- Mirrors fix from [accordproject/concerto-cli#97](https://github.com/accordproject/concerto-cli/pull/97)
- Closes #910
- Part of [accordproject/concerto#1190](https://github.com/accordproject/concerto/issues/1190)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)