### PR TITLE
chore(stale): adopt centralized reusable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Stale
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    uses: accordproject/.github/.github/workflows/stale.yml@main
+    # All inputs are optional. Override here to tune this repo only;
+    # change accordproject/.github to tune every repo at once.
+    # with:
+    #   enable-close: false
+    #   days-before-issue-stale: 60
+    #   days-before-pr-stale: 15
+    #   days-before-close: 10


### PR DESCRIPTION
## Summary

Adopts the centralized reusable stale workflow defined in [accordproject/.github#2](https://github.com/accordproject/.github/pull/2). This repo's `.github/workflows/stale.yml` is now a thin caller — all logic (stale periods, the `maintainer-engaged` label policy, auto-close gating) lives in one place across the org.

## Why

- One PR to change stale behaviour for every repo, instead of N.
- A single kill-switch (`enable-close: false`) can disable auto-close org-wide.
- The `maintainer-engaged` policy keeps stale-marking on everything but only auto-closes items where someone with `author_association` of `OWNER`, `MEMBER`, or `COLLABORATOR` has commented or reviewed — so contributor work that maintainers never touched is never silently closed.

## Merge order

Merge [accordproject/.github#2](https://github.com/accordproject/.github/pull/2) **first**. The `uses: accordproject/.github/.github/workflows/stale.yml@main` reference in this PR resolves against `main` of that repo.

## Tuning this repo only

Uncomment values under `with:` in `.github/workflows/stale.yml` to override defaults for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
