### PR TITLE
Fix cicero validate command behavior

### DIFF
--- a/packages/cicero-cli/README.md
+++ b/packages/cicero-cli/README.md
@@ -16,6 +16,56 @@ npm install -g @accordproject/cicero-cli
 
 Run `cicero --help` for usage instructions.
 
+### Commands
+
+| Command | Purpose |
+|---------|---------|
+| `cicero archive` | Create a `.cta` template archive from a template directory |
+| `cicero compile` | Generate code for a target platform from a template's model |
+| `cicero get` | Save local copies of a template's external model dependencies |
+| `cicero validate` | Validate a template directory without producing output artifacts |
+| `cicero verify` | Verify the signature of a signed template archive |
+
+### `cicero validate`
+
+Fast, side-effect-free check that a template directory is well-formed. Runs
+layered structural checks (package.json, grammar, model) followed by a full
+coherence check via `Template.fromDirectory`. Emits a per-check `✓`/`✗`
+summary and exits with code `1` on any failure — suitable for CI pipelines.
+
+```bash
+cicero validate --template <path> [--warnings]
+```
+
+Options:
+- `--template <path>` — path to the template directory (defaults to `.`)
+- `--warnings` — surface non-fatal warnings (e.g. orphan `logic/` directory,
+  since Ergo is no longer executed by `cicero-core`)
+
+Example (valid template):
+
+```
+$ cicero validate --template ./my-template
+✓ package.json valid
+✓ text/grammar.tem.md found
+✓ model/ found 2 .cto file(s)
+✓ Template coherence grammar parsed, model validated, template variables match the model
+
+Template is valid.
+```
+
+Example (broken template):
+
+```
+$ cicero validate --template ./my-template
+✓ package.json valid
+✓ text/grammar.tem.md found
+✓ model/ found 1 .cto file(s)
+✗ model/ — Undeclared type "PaymentAmount" in "property ...TemplateModel.amount"
+
+Validation failed. 1 error found.
+```
+
 ## License <a name="license"></a>
 Accord Project source code files are made available under the Apache License, Version 2.0 (Apache-2.0), located in the LICENSE file. Accord Project documentation files are made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0), available at http://creativecommons.org/licenses/by/4.0/.
 

--- a/packages/cicero-cli/README.md
+++ b/packages/cicero-cli/README.md
@@ -34,19 +34,20 @@ coherence check via `Template.fromDirectory`. Emits a per-check `✓`/`✗`
 summary and exits with code `1` on any failure — suitable for CI pipelines.
 
 ```bash
-cicero validate --template <path> [--warnings]
+cicero validate [template] [--warnings]
 ```
 
 Options:
-- `--template <path>` — path to the template directory (defaults to `.`)
+- `[template]` — path to the template directory (defaults to `.`)
+- `--template <path>` — alternative named form of the template path
 - `--warnings` — surface non-fatal warnings (e.g. orphan `logic/` directory,
   since Ergo is no longer executed by `cicero-core`)
 
 Example (valid template):
 
 ```
-$ cicero validate --template ./my-template
-✓ package.json valid
+$ cicero validate ./my-template
+✓ package.json contains required template metadata
 ✓ text/grammar.tem.md found
 ✓ model/ found 2 .cto file(s)
 ✓ Template coherence grammar parsed, model validated, template variables match the model
@@ -57,8 +58,8 @@ Template is valid.
 Example (broken template):
 
 ```
-$ cicero validate --template ./my-template
-✓ package.json valid
+$ cicero validate ./my-template
+✓ package.json contains required template metadata
 ✓ text/grammar.tem.md found
 ✓ model/ found 1 .cto file(s)
 ✗ model/ — Undeclared type "PaymentAmount" in "property ...TemplateModel.amount"

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -160,6 +160,57 @@ require('yargs')
             return;
         }
     })
+    .command('validate', 'validate a template without producing output artifacts', (yargs) => {
+        yargs.option('template', {
+            describe: 'path to the template directory',
+            type: 'string'
+        });
+        yargs.option('warnings', {
+            describe: 'surface non-fatal warnings (e.g. orphaned logic/ directory)',
+            type: 'boolean',
+            default: false
+        });
+    }, async (argv) => {
+        if (argv.verbose) {
+            Logger.info(`validate template at ${argv.template}`);
+        }
+
+        try {
+            argv = Commands.validateValidateArgs(argv);
+            const { results, warnings, valid } = await Commands.validate(argv.template, {
+                warnings: argv.warnings,
+            });
+
+            for (const r of results) {
+                const line = r.ok
+                    ? `\u2713 ${r.layer} ${r.message}`
+                    : `\u2717 ${r.layer} \u2014 ${r.message}`;
+                if (r.ok) {
+                    console.log(line);
+                } else {
+                    console.error(line);
+                }
+            }
+            if (warnings.length > 0) {
+                console.log('');
+                for (const w of warnings) {
+                    console.log(`\u26A0 ${w}`);
+                }
+            }
+            console.log('');
+            if (valid) {
+                console.log('Template is valid.');
+            } else {
+                const errCount = results.filter((r) => !r.ok).length;
+                console.error(`Validation failed. ${errCount} error${errCount === 1 ? '' : 's'} found.`);
+                process.exitCode = 1;
+            }
+        } catch (err) {
+            Logger.error(err.message);
+            process.exitCode = 1;
+        }
+    })
+
     .command('get', 'save local copies of external dependencies', (yargs) => {
         yargs.option('template', {
             describe: 'path to the template',

--- a/packages/cicero-cli/index.js
+++ b/packages/cicero-cli/index.js
@@ -160,7 +160,11 @@ require('yargs')
             return;
         }
     })
-    .command('validate', 'validate a template without producing output artifacts', (yargs) => {
+    .command('validate [template]', 'validate a template without producing output artifacts', (yargs) => {
+        yargs.positional('template', {
+            describe: 'path to the template directory',
+            type: 'string'
+        });
         yargs.option('template', {
             describe: 'path to the template directory',
             type: 'string'

--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -239,6 +239,154 @@ class Commands {
                 return `Loaded external models in '${output}'.`;
             });
     }
+
+    /**
+     * Set default params before we validate a template.
+     *
+     * Unlike validateCommonArgs, this does NOT throw on missing/malformed
+     * package.json — reporting those conditions is the purpose of the validate
+     * command itself.
+     *
+     * @param {object} argv the inbound argument values object
+     * @returns {object} a modified argument object
+     */
+    static validateValidateArgs(argv) {
+        if (argv._.length === 2) {
+            argv.template = argv._[1];
+        }
+        if (!argv.template) {
+            Logger.info('Using current directory as template folder');
+            argv.template = '.';
+        }
+        argv.template = path.resolve(argv.template);
+        return argv;
+    }
+
+    /**
+     * Validate a template directory in isolation, with layered per-check output.
+     *
+     * Runs a sequence of structural and coherence checks and returns a result
+     * object describing what passed and what failed. Unlike `archive`, `compile`,
+     * or `parse`, this command produces no output artifacts and requires no
+     * sample file. It is intended as a fast CI-friendly lint step.
+     *
+     * Checks, in order:
+     *   1. template path exists and is a directory
+     *   2. package.json exists, parses as JSON, and contains an accordproject section
+     *   3. text/grammar.tem.md exists
+     *   4. model/ exists and contains at least one .cto file
+     *   5. overall template coherence via Template.fromDirectory
+     *      (parses grammar, validates model, checks variable/model agreement)
+     *
+     * The first four checks are per-file and short-circuit on the first failure
+     * so the error surface pinpoints the broken layer. The last check wraps
+     * cicero-core's own loader and surfaces its error message verbatim when it
+     * throws.
+     *
+     * @param {string} templatePath - path to the template directory
+     * @param {object} [options] - optional configuration
+     * @param {boolean} [options.warnings] - surface non-fatal warnings
+     * @returns {Promise<object>} a result object with `results` (per-check
+     *   entries), `warnings` (string array), and `valid` (boolean)
+     */
+    static async validate(templatePath, options = {}) {
+        const results = [];
+        const warnings = [];
+
+        // Check 1: path exists and is a directory
+        if (!fs.existsSync(templatePath)) {
+            results.push({ layer: 'path', ok: false, message: `template path not found: ${templatePath}` });
+            return { results, warnings, valid: false };
+        }
+        if (!fs.lstatSync(templatePath).isDirectory()) {
+            results.push({
+                layer: 'path',
+                ok: false,
+                message: `${templatePath} is not a directory. Use 'cicero verify' for .cta archives.`,
+            });
+            return { results, warnings, valid: false };
+        }
+
+        // Check 2: package.json exists, parses, has accordproject section
+        const pkgPath = path.resolve(templatePath, 'package.json');
+        if (!fs.existsSync(pkgPath)) {
+            results.push({ layer: 'package.json', ok: false, message: 'file not found' });
+            return { results, warnings, valid: false };
+        }
+        let pkg;
+        try {
+            pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        } catch (err) {
+            results.push({ layer: 'package.json', ok: false, message: `not valid JSON: ${err.message}` });
+            return { results, warnings, valid: false };
+        }
+        if (!pkg.accordproject) {
+            results.push({
+                layer: 'package.json',
+                ok: false,
+                message: 'missing "accordproject" section (required for Cicero templates)',
+            });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'package.json', ok: true, message: 'valid' });
+
+        // Check 3: grammar.tem.md exists
+        const grammarPath = path.resolve(templatePath, 'text', 'grammar.tem.md');
+        if (!fs.existsSync(grammarPath)) {
+            results.push({ layer: 'text/grammar.tem.md', ok: false, message: 'file not found' });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'text/grammar.tem.md', ok: true, message: 'found' });
+
+        // Check 4: model/ exists and contains .cto files
+        const modelDir = path.resolve(templatePath, 'model');
+        if (!fs.existsSync(modelDir) || !fs.lstatSync(modelDir).isDirectory()) {
+            results.push({ layer: 'model/', ok: false, message: 'model directory not found' });
+            return { results, warnings, valid: false };
+        }
+        const ctoFiles = fs.readdirSync(modelDir).filter((f) => f.endsWith('.cto'));
+        if (ctoFiles.length === 0) {
+            results.push({ layer: 'model/', ok: false, message: 'no .cto files found' });
+            return { results, warnings, valid: false };
+        }
+        results.push({ layer: 'model/', ok: true, message: `found ${ctoFiles.length} .cto file(s)` });
+
+        // Check 5: full coherence via Template.fromDirectory
+        try {
+            await Commands.loadTemplate(templatePath, options);
+            results.push({
+                layer: 'Template coherence',
+                ok: true,
+                message: 'grammar parsed, model validated, template variables match the model',
+            });
+        } catch (err) {
+            const msg = err.message || String(err);
+            let layer = 'Template coherence';
+            const lower = msg.toLowerCase();
+            if (lower.includes('grammar')) {
+                layer = 'text/grammar.tem.md';
+            } else if (lower.includes('.cto') || lower.includes('namespace') || lower.includes('type ')) {
+                layer = 'model/';
+            }
+            results.push({ layer, ok: false, message: msg });
+        }
+
+        // Warnings: Ergo logic files are ignored at runtime
+        if (options.warnings) {
+            const logicDir = path.resolve(templatePath, 'logic');
+            if (fs.existsSync(logicDir) && fs.lstatSync(logicDir).isDirectory()) {
+                const logicFiles = fs.readdirSync(logicDir);
+                if (logicFiles.length > 0) {
+                    warnings.push(
+                        `logic/ directory contains ${logicFiles.length} file(s); Ergo is no longer executed by cicero-core and these are ignored at runtime`
+                    );
+                }
+            }
+        }
+
+        const valid = results.every((r) => r.ok);
+        return { results, warnings, valid };
+    }
 }
 
 module.exports = Commands;

--- a/packages/cicero-cli/lib/commands.js
+++ b/packages/cicero-cli/lib/commands.js
@@ -30,6 +30,27 @@ const { CodeGen } = require('@accordproject/concerto-codegen');
  */
 class Commands {
     /**
+     * Resolve the template path from positional or named CLI arguments.
+     *
+     * @param {object} argv the inbound argument values object
+     * @returns {object} a modified argument object
+     */
+    static resolveTemplateArg(argv) {
+        // the user typed 'cicero [command] [template]'
+        if(argv._.length === 2){
+            argv.template = argv._[1];
+        }
+
+        if(!argv.template){
+            Logger.info('Using current directory as template folder');
+            argv.template = '.';
+        }
+
+        argv.template = path.resolve(argv.template);
+        return argv;
+    }
+
+    /**
      * Whether the template path is to a file (template archive)
      * @param {string} templatePath - path to the template directory or archive
      * @return {boolean} true if the path is to a file, false otherwise
@@ -54,34 +75,69 @@ class Commands {
     }
 
     /**
+     * Parse package.json from a template directory.
+     *
+     * @param {string} templatePath - path to the template directory
+     * @returns {object} parse result with `ok`, `message`, and `packageJson`
+     */
+    static validateTemplatePackageJson(templatePath) {
+        const pkgPath = path.resolve(templatePath, 'package.json');
+        if (!fs.existsSync(pkgPath)) {
+            return { ok: false, message: 'file not found' };
+        }
+
+        let packageJson;
+        try {
+            packageJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        } catch (err) {
+            return { ok: false, message: `not valid JSON: ${err.message}` };
+        }
+
+        if (!packageJson || typeof packageJson !== 'object' || Array.isArray(packageJson)) {
+            return { ok: false, message: 'must contain a JSON object' };
+        }
+
+        const missingFields = [];
+        if (!packageJson.name) {
+            missingFields.push('name');
+        }
+        if (!packageJson.version) {
+            missingFields.push('version');
+        }
+        if (!packageJson.accordproject || typeof packageJson.accordproject !== 'object' || Array.isArray(packageJson.accordproject)) {
+            missingFields.push('accordproject');
+        } else if (!packageJson.accordproject.cicero) {
+            missingFields.push('accordproject.cicero');
+        }
+
+        if (missingFields.length > 0) {
+            const fields = missingFields.map((field) => `"${field}"`).join(', ');
+            return { ok: false, message: `missing required field(s): ${fields}` };
+        }
+
+        return {
+            ok: true,
+            message: 'contains required template metadata',
+            packageJson,
+        };
+    }
+
+    /**
      * Common default params before we create an archive using a template
      *
      * @param {object} argv - the inbound argument values object
      * @returns {object} a modfied argument object
      */
     static validateCommonArgs(argv) {
-        // the user typed 'cicero [command] [template]'
-        if(argv._.length === 2){
-            argv.template = argv._[1];
-        }
-
-        if(!argv.template){
-            Logger.info('Using current directory as template folder');
-            argv.template = '.';
-        }
-
-        argv.template = path.resolve(argv.template);
+        argv = Commands.resolveTemplateArg(argv);
 
         if (!Commands.isTemplateArchive(argv.template)) {
-            const packageJsonExists = fs.existsSync(path.resolve(argv.template,'package.json'));
-            let isAPTemplate = false;
-            if(packageJsonExists){
-                let packageJsonContents = JSON.parse(fs.readFileSync(path.resolve(argv.template,'package.json')),'utf8');
-                isAPTemplate = packageJsonContents.accordproject;
-            }
-
-            if(!packageJsonExists || !isAPTemplate){
-                throw new Error(`${argv.template} is not a valid cicero template. Make sure that package.json exists and that it has a cicero entry.`);
+            const packageValidation = Commands.validateTemplatePackageJson(argv.template);
+            if (!packageValidation.ok) {
+                throw new Error(
+                    `${argv.template} is not a valid cicero template. ` +
+                    'Make sure that package.json exists and contains the required Cicero metadata.'
+                );
             }
         }
 
@@ -251,15 +307,7 @@ class Commands {
      * @returns {object} a modified argument object
      */
     static validateValidateArgs(argv) {
-        if (argv._.length === 2) {
-            argv.template = argv._[1];
-        }
-        if (!argv.template) {
-            Logger.info('Using current directory as template folder');
-            argv.template = '.';
-        }
-        argv.template = path.resolve(argv.template);
-        return argv;
+        return Commands.resolveTemplateArg(argv);
     }
 
     /**
@@ -272,7 +320,8 @@ class Commands {
      *
      * Checks, in order:
      *   1. template path exists and is a directory
-     *   2. package.json exists, parses as JSON, and contains an accordproject section
+     *   2. package.json exists, parses as JSON, and contains the required
+     *      template metadata fields
      *   3. text/grammar.tem.md exists
      *   4. model/ exists and contains at least one .cto file
      *   5. overall template coherence via Template.fromDirectory
@@ -307,28 +356,17 @@ class Commands {
             return { results, warnings, valid: false };
         }
 
-        // Check 2: package.json exists, parses, has accordproject section
-        const pkgPath = path.resolve(templatePath, 'package.json');
-        if (!fs.existsSync(pkgPath)) {
-            results.push({ layer: 'package.json', ok: false, message: 'file not found' });
-            return { results, warnings, valid: false };
-        }
-        let pkg;
-        try {
-            pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-        } catch (err) {
-            results.push({ layer: 'package.json', ok: false, message: `not valid JSON: ${err.message}` });
-            return { results, warnings, valid: false };
-        }
-        if (!pkg.accordproject) {
+        // Check 2: package.json exists, parses, and has required metadata
+        const packageValidation = Commands.validateTemplatePackageJson(templatePath);
+        if (!packageValidation.ok) {
             results.push({
                 layer: 'package.json',
                 ok: false,
-                message: 'missing "accordproject" section (required for Cicero templates)',
+                message: packageValidation.message,
             });
             return { results, warnings, valid: false };
         }
-        results.push({ layer: 'package.json', ok: true, message: 'valid' });
+        results.push({ layer: 'package.json', ok: true, message: packageValidation.message });
 
         // Check 3: grammar.tem.md exists
         const grammarPath = path.resolve(templatePath, 'text', 'grammar.tem.md');
@@ -351,9 +389,11 @@ class Commands {
         }
         results.push({ layer: 'model/', ok: true, message: `found ${ctoFiles.length} .cto file(s)` });
 
-        // Check 5: full coherence via Template.fromDirectory
+        // Check 5: full coherence via Template.fromDirectory without mutating
+        // the template directory or reaching out to the network.
         try {
-            await Commands.loadTemplate(templatePath, options);
+            const loadOptions = Object.assign({}, options, { offline: true });
+            await Commands.loadTemplate(templatePath, loadOptions);
             results.push({
                 layer: 'Template coherence',
                 ok: true,

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -319,3 +319,125 @@ describe('#verify', async () => {
         return Commands.verify(templatePath).should.be.rejectedWith('Template\'s author signature is invalid!');
     });
 });
+
+describe('#validateValidateArgs', () => {
+    it('no args specified — defaults to cwd', () => {
+        process.chdir(path.resolve(__dirname, 'data/latedeliveryandpenalty/'));
+        const args = Commands.validateValidateArgs({
+            _: ['validate'],
+        });
+        args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
+    });
+    it('template arg specified', () => {
+        process.chdir(path.resolve(__dirname));
+        const args = Commands.validateValidateArgs({
+            _: ['validate', 'data/latedeliveryandpenalty/'],
+        });
+        args.template.should.match(/cicero-cli[/\\]test[/\\]data[/\\]latedeliveryandpenalty$/);
+    });
+    it('does not throw on missing package.json — reporting that is the whole point', () => {
+        process.chdir(path.resolve(__dirname, 'data/'));
+        // Unlike validateCommonArgs, this must NOT throw. If it did, the validate
+        // command would crash on exactly the condition it is supposed to report.
+        (() => Commands.validateValidateArgs({
+            _: ['validate'],
+        })).should.not.throw();
+    });
+});
+
+describe('#validate', () => {
+    const validateFixtures = path.resolve(__dirname, 'data/validate');
+
+    it('passes on a known-good template', async () => {
+        const result = await Commands.validate(
+            path.resolve(__dirname, 'data/latedeliveryandpenalty')
+        );
+        result.valid.should.equal(true);
+        result.results.should.be.an('array').that.is.not.empty;
+        result.results.every((r) => r.ok).should.equal(true);
+    });
+
+    it('fails when the path does not exist', async () => {
+        const result = await Commands.validate('/does/not/exist/anywhere');
+        result.valid.should.equal(false);
+        result.results.should.have.lengthOf(1);
+        result.results[0].layer.should.equal('path');
+        result.results[0].ok.should.equal(false);
+    });
+
+    it('fails and short-circuits when package.json is missing', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-package-json'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.ok.should.equal(false);
+        last.message.should.match(/not found/);
+    });
+
+    it('fails when package.json is not valid JSON', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'invalid-json-package'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/not valid JSON/);
+    });
+
+    it('fails when package.json has no accordproject section', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'no-accord-section'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/accordproject/);
+    });
+
+    it('fails when text/grammar.tem.md is missing', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-grammar'));
+        result.valid.should.equal(false);
+        // package.json should have passed first
+        result.results[0].layer.should.equal('package.json');
+        result.results[0].ok.should.equal(true);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('text/grammar.tem.md');
+        last.ok.should.equal(false);
+    });
+
+    it('fails when model/ has no .cto files', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-model'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('model/');
+        last.ok.should.equal(false);
+    });
+
+    it('fails on a .cto that references an unknown type', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'invalid-cto'));
+        result.valid.should.equal(false);
+        // The structural checks (package.json, grammar, model/) should all pass
+        // — the failure is in the Template coherence layer.
+        const failing = result.results.filter((r) => !r.ok);
+        failing.should.have.lengthOf(1);
+        failing[0].ok.should.equal(false);
+        // The error message should mention the unknown type
+        failing[0].message.should.match(/DoesNotExist/);
+    });
+
+    it('emits no warnings when --warnings is false', async () => {
+        const result = await Commands.validate(
+            path.resolve(__dirname, 'data/latedeliveryandpenalty'),
+            { warnings: false }
+        );
+        result.warnings.should.be.an('array').that.is.empty;
+    });
+
+    it('surfaces orphan logic/ directory as a warning when --warnings is true', async () => {
+        const result = await Commands.validate(
+            path.resolve(validateFixtures, 'has-orphan-logic'),
+            { warnings: true }
+        );
+        // The template itself is valid — the logic dir is just flagged.
+        result.valid.should.equal(true);
+        result.warnings.should.be.an('array').with.lengthOf(1);
+        result.warnings[0].should.match(/logic\//);
+        result.warnings[0].should.match(/Ergo/);
+    });
+});

--- a/packages/cicero-cli/test/cli.js
+++ b/packages/cicero-cli/test/cli.js
@@ -18,6 +18,7 @@ const chai = require('chai');
 const path = require('path');
 const tmp = require('tmp-promise');
 const fs = require('fs');
+const childProcess = require('child_process');
 
 const Template = require('@accordproject/cicero-core').Template;
 const {CodeGen} = require('@accordproject/concerto-codegen');
@@ -67,7 +68,7 @@ describe('#validateCompileArgs', () => {
         process.chdir(path.resolve(__dirname, 'data/'));
         (() => Commands.validateCompileArgs({
             _: ['compile'],
-        })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a cicero entry.');
+        })).should.throw(' not a valid cicero template. Make sure that package.json exists and contains the required Cicero metadata.');
     });
 });
 
@@ -145,7 +146,7 @@ describe('#validateArchiveArgs', () => {
         process.chdir(path.resolve(__dirname, 'data/'));
         (() => Commands.validateArchiveArgs({
             _: ['archive']
-        })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a cicero entry.');
+        })).should.throw(' not a valid cicero template. Make sure that package.json exists and contains the required Cicero metadata.');
     });
 });
 
@@ -256,7 +257,7 @@ describe('#validateGetArgs', () => {
         process.chdir(path.resolve(__dirname, 'data/'));
         (() => Commands.validateGetArgs({
             _: ['get']
-        })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a cicero entry.');
+        })).should.throw(' not a valid cicero template. Make sure that package.json exists and contains the required Cicero metadata.');
     });
 });
 
@@ -295,7 +296,7 @@ describe('#validateVerfiyArgs', () => {
         process.chdir(path.resolve(__dirname, 'data/'));
         (() => Commands.validateVerifyArgs({
             _: ['verify']
-        })).should.throw(' not a valid cicero template. Make sure that package.json exists and that it has a cicero entry.');
+        })).should.throw(' not a valid cicero template. Make sure that package.json exists and contains the required Cicero metadata.');
     });
 });
 
@@ -347,6 +348,7 @@ describe('#validateValidateArgs', () => {
 
 describe('#validate', () => {
     const validateFixtures = path.resolve(__dirname, 'data/validate');
+    const cliPath = path.resolve(__dirname, '..', 'index.js');
 
     it('passes on a known-good template', async () => {
         const result = await Commands.validate(
@@ -388,6 +390,22 @@ describe('#validate', () => {
         const last = result.results[result.results.length - 1];
         last.layer.should.equal('package.json');
         last.message.should.match(/accordproject/);
+    });
+
+    it('fails when package.json is missing a required npm field', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-name'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/"name"/);
+    });
+
+    it('fails when package.json is missing accordproject.cicero', async () => {
+        const result = await Commands.validate(path.resolve(validateFixtures, 'missing-cicero-version'));
+        result.valid.should.equal(false);
+        const last = result.results[result.results.length - 1];
+        last.layer.should.equal('package.json');
+        last.message.should.match(/accordproject\.cicero/);
     });
 
     it('fails when text/grammar.tem.md is missing', async () => {
@@ -439,5 +457,20 @@ describe('#validate', () => {
         result.warnings.should.be.an('array').with.lengthOf(1);
         result.warnings[0].should.match(/logic\//);
         result.warnings[0].should.match(/Ergo/);
+    });
+
+    it('accepts the template path as a positional CLI argument', () => {
+        const result = childProcess.spawnSync(
+            process.execPath,
+            [cliPath, 'validate', path.resolve(validateFixtures, 'no-accord-section')],
+            {
+                cwd: path.resolve(__dirname, '..'),
+                encoding: 'utf8',
+            }
+        );
+
+        result.status.should.equal(1);
+        result.stderr.should.match(/package\.json/);
+        result.stderr.should.not.match(/Unknown argument/);
     });
 });

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/logic/logic.ergo
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/logic/logic.ergo
@@ -1,0 +1,1 @@
+// Legacy Ergo file — no longer executed

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.orphanlogic@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/package.json
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "has-orphan-logic",
+    "version": "0.0.1",
+    "description": "Fixture: valid template that still carries an orphan logic/ directory",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/has-orphan-logic/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/has-orphan-logic/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/invalid-cto/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.invalidcto@1.0.0
+
+@template
+concept TemplateModel {
+  o DoesNotExist name
+}

--- a/packages/cicero-cli/test/data/validate/invalid-cto/package.json
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "invalid-cto",
+    "version": "0.0.1",
+    "description": "Fixture: .cto references an unknown type so model validation fails",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/invalid-cto/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/invalid-cto/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.badjson@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/package.json
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/package.json
@@ -1,0 +1,1 @@
+{ this is not valid json

--- a/packages/cicero-cli/test/data/validate/invalid-json-package/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/invalid-json-package/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-cicero-version/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-cicero-version/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missingciceroversion@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-cicero-version/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-cicero-version/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "missing-cicero-version",
+    "version": "0.0.1",
+    "description": "Fixture: package.json is missing accordproject.cicero",
+    "accordproject": {
+        "template": "clause"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-cicero-version/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-cicero-version/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-grammar/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-grammar/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missinggrammar@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-grammar/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-grammar/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "missing-grammar",
+    "version": "0.0.1",
+    "description": "Fixture: valid package.json but no text/grammar.tem.md",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-model/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-model/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "missing-model",
+    "version": "0.0.1",
+    "description": "Fixture: valid package.json + grammar but no model/ directory",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-model/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-model/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-name/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-name/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missingname@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-name/package.json
+++ b/packages/cicero-cli/test/data/validate/missing-name/package.json
@@ -1,0 +1,8 @@
+{
+    "version": "0.0.1",
+    "description": "Fixture: package.json is missing the required name field",
+    "accordproject": {
+        "template": "clause",
+        "cicero": "^0.25.0"
+    }
+}

--- a/packages/cicero-cli/test/data/validate/missing-name/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-name/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/missing-package-json/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/missing-package-json/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.missingpkg@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/missing-package-json/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/missing-package-json/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.

--- a/packages/cicero-cli/test/data/validate/no-accord-section/model/model.cto
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/model/model.cto
@@ -1,0 +1,6 @@
+namespace org.accordproject.validate.noaccord@1.0.0
+
+@template
+concept TemplateModel {
+  o String name
+}

--- a/packages/cicero-cli/test/data/validate/no-accord-section/package.json
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "no-accord-section",
+    "version": "0.0.1",
+    "description": "Fixture: package.json has no accordproject entry"
+}

--- a/packages/cicero-cli/test/data/validate/no-accord-section/text/grammar.tem.md
+++ b/packages/cicero-cli/test/data/validate/no-accord-section/text/grammar.tem.md
@@ -1,0 +1,1 @@
+Hello {{name}}.


### PR DESCRIPTION
## What changed
- accept `cicero validate [template]` as a positional CLI argument in addition to `--template`
- factor template path resolution so `validate` no longer duplicates argument handling already used by other commands
- tighten `package.json` validation to check the metadata required for a valid Cicero template, including `name`, `version`, `accordproject`, and `accordproject.cicero`
- run the full validation coherence check in offline mode so `cicero validate` stays side-effect-free and does not fetch or write external models
- add regression tests and fixtures for missing required package metadata and for the positional CLI path flow
- update the CLI README examples to reflect the accepted invocation and new package metadata messaging

## Why
This follow-up addresses review issues on PR #902:
- the implementation duplicated CLI path normalization logic instead of reusing the shared flow
- `package.json` validation only checked for an `accordproject` section, which was narrower than the metadata the template loader actually requires
- the `validate` command declaration did not accept a positional template path, so `cicero validate some/template` failed with `Unknown argument`
- the validation coherence check could trigger network fetches and directory writes, which undermined the goal of a fast, isolated validation command

## Impact
- `cicero validate` now behaves more like the other CLI commands and works with a positional template path
- validation failures point to missing required template metadata earlier and more clearly
- the command remains a safer CI-friendly lint step because it avoids mutating the template directory during validation

## Validation
- `npm run lint`
- `npx mocha --timeout 30000 test/cli.js --grep "bad package\.json|#validateValidateArgs|good template|path does not exist|short-circuits|not valid JSON|no accordproject section|required npm field|accordproject.cicero|grammar.tem.md|no \.cto|unknown type|warnings is false|orphan logic|positional CLI argument"`