### PR TITLE
fix: auto-sync fixture versions during release bumps

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -24,4 +24,15 @@ git remote add upstream "https://github.com/accordproject/template-archive.git"
 
 **Note:** Template Archive no longer uses `lerna bootstrap`, since `lerna bootstrap` was deprecated at lerne version 7.x.  Now `npm install` automatically resolves packages defined within the "Workspaces" definition inside `package.json`.
 
+### Release Version Sync
+
+The publish workflow runs `node ./scripts/bump_version.js <tag-or-version>` before `npm version` and `npm publish`.
+That script automatically syncs managed Accord Project version references across:
+
+- workspace package dependencies for internal packages
+- template and fixture `package.json` files under `packages/*/test/data/**`
+- both `accordproject.cicero` and managed `@accordproject/*` dependency entries in those fixture manifests
+
+Nested fixture `node_modules` content is treated as test data and is intentionally excluded from those updates.
+
 [apdev]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md

--- a/packages/cicero-core/test/data/block-join/package.json
+++ b/packages/cicero-core/test/data/block-join/package.json
@@ -30,6 +30,6 @@
         "withholding"
     ],
     "dependencies": {
-        "@accordproject/cicero-cli": "^0.20.1"
+        "@accordproject/cicero-cli": "^0.27.0"
     }
 }

--- a/scripts/bump_version.js
+++ b/scripts/bump_version.js
@@ -16,43 +16,242 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const glob = require('glob');
+const semver = require('semver');
 
 /**
- * This script updates the devDependencies and dependencies in the workspaces
- * to match the version specified by the given parameter.
- * The expected parameter should be the tag for the package.
+ * This script updates managed Accord Project version references during release.
+ * It updates workspace package dependencies and repo-tracked template fixture
+ * manifests that declare a Cicero compatibility range or internal package
+ * dependency.
  *
  * Example:
- * node ./script/bump_version.js <tag>
+ * node ./scripts/bump_version.js <tag-or-version>
  */
 
-const workspacesPattern = 'packages/*/package.json'; // Adjust this pattern based on your workspace setup
-const packageNames = [
-    "@accordproject/cicero-cli",
-    "@accordproject/cicero-core",
-    "@accordproject/generator-cicero-template",
+const workspacePattern = 'packages/*/package.json';
+const fixturePattern = 'packages/*/test/data/**/package.json';
+const fixtureIgnorePatterns = ['**/node_modules/**'];
+const managedPackageNames = [
+    '@accordproject/cicero-cli',
+    '@accordproject/cicero-core',
+    '@accordproject/generator-cicero-template',
 ];
 
-function bumpDependencies() {
-    const targetPackageVersion = process.argv[2].replace(/^v/, '');
-    const workspacePackages = glob.sync(workspacesPattern);
+/**
+ * @param {string} rawVersion the raw CLI version or tag
+ * @returns {string} normalized semver version
+ */
+function normalizeTargetVersion(rawVersion) {
+    if (!rawVersion) {
+        throw new Error('A version argument is required.');
+    }
 
-    workspacePackages.forEach((packagePath) => {
-        const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    const targetVersion = rawVersion.replace(/^v/, '');
 
-        ['dependencies', 'devDependencies'].forEach((depType) => {
-            packageNames.forEach(dep => {
-                if (packageJson[depType] && (dep in packageJson[depType])) {
-                    packageJson[depType][dep] = targetPackageVersion;
-                }
-            });
-        });
+    if (!semver.valid(targetVersion)) {
+        throw new Error(`Invalid version "${rawVersion}". Expected a semantic version like 0.27.0 or v0.27.0.`);
+    }
 
-        fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf8');
-    });
-
-    console.log('Dependencies updated successfully!');
+    return targetVersion;
 }
 
-bumpDependencies();
+/**
+ * @param {string} content the original file content
+ * @returns {number|null} indentation width, or null for a single-line file
+ */
+function detectIndentation(content) {
+    if (!content.includes('\n')) {
+        return null;
+    }
+
+    const match = content.match(/^\s+"/m);
+    return match ? match[0].length - 1 : 2;
+}
+
+/**
+ * @param {object} packageJson the package json object
+ * @param {string} originalContent the original file content
+ * @returns {string} serialized package json preserving the original style
+ */
+function serializePackageJson(packageJson, originalContent) {
+    const indentation = detectIndentation(originalContent);
+    const hasTrailingNewline = originalContent.endsWith('\n');
+    const serialized = indentation === null ?
+        JSON.stringify(packageJson) :
+        JSON.stringify(packageJson, null, indentation);
+
+    return hasTrailingNewline ? `${serialized}\n` : serialized;
+}
+
+/**
+ * @param {string} currentValue the current version or range
+ * @param {string} targetVersion the target version
+ * @returns {string} updated version string
+ */
+function rewriteVersion(currentValue, targetVersion) {
+    if (typeof currentValue !== 'string') {
+        return currentValue;
+    }
+
+    if (currentValue.startsWith('^') || currentValue.startsWith('~')) {
+        return `${currentValue[0]}${targetVersion}`;
+    }
+
+    return targetVersion;
+}
+
+/**
+ * @param {object} packageJson the package json object
+ * @param {string} depType dependency section to update
+ * @param {string} targetVersion target version
+ * @param {boolean} preserveRange whether to preserve ^ or ~ from the original value
+ * @returns {boolean} true if a dependency was changed
+ */
+function updateManagedDependencies(packageJson, depType, targetVersion, preserveRange) {
+    let changed = false;
+    const dependencyMap = packageJson[depType];
+
+    if (!dependencyMap) {
+        return changed;
+    }
+
+    managedPackageNames.forEach((depName) => {
+        if (depName in dependencyMap) {
+            const nextValue = preserveRange ?
+                rewriteVersion(dependencyMap[depName], targetVersion) :
+                targetVersion;
+
+            if (dependencyMap[depName] !== nextValue) {
+                dependencyMap[depName] = nextValue;
+                changed = true;
+            }
+        }
+    });
+
+    return changed;
+}
+
+/**
+ * @param {string} manifestPath path to package.json
+ * @returns {{packageJson: object, originalContent: string}} parsed manifest data
+ */
+function readManifest(manifestPath) {
+    const originalContent = fs.readFileSync(manifestPath, 'utf8');
+    return {
+        packageJson: JSON.parse(originalContent),
+        originalContent,
+    };
+}
+
+/**
+ * @param {string[]} manifestPaths package.json file paths
+ * @param {(packageJson: object) => boolean} mutateManifest mutator returning whether the manifest changed
+ * @returns {number} number of files updated
+ */
+function updateManifestFiles(manifestPaths, mutateManifest) {
+    let updatedCount = 0;
+
+    manifestPaths.forEach((manifestPath) => {
+        const { packageJson, originalContent } = readManifest(manifestPath);
+
+        if (mutateManifest(packageJson)) {
+            fs.writeFileSync(manifestPath, serializePackageJson(packageJson, originalContent), 'utf8');
+            updatedCount++;
+        }
+    });
+
+    return updatedCount;
+}
+
+/**
+ * @param {string} cwd working directory root
+ * @returns {string[]} workspace manifest paths
+ */
+function getWorkspaceManifestPaths(cwd) {
+    return glob.sync(workspacePattern, { cwd, nodir: true })
+        .map((manifestPath) => path.join(cwd, manifestPath));
+}
+
+/**
+ * @param {string} cwd working directory root
+ * @returns {string[]} fixture manifest paths
+ */
+function getFixtureManifestPaths(cwd) {
+    return glob.sync(fixturePattern, {
+        cwd,
+        nodir: true,
+        ignore: fixtureIgnorePatterns,
+    }).map((manifestPath) => path.join(cwd, manifestPath));
+}
+
+/**
+ * @param {string} targetVersion target version
+ * @param {{cwd?: string}} [options] script options
+ * @returns {{targetVersion: string, updatedWorkspaceCount: number, updatedFixtureCount: number}} update summary
+ */
+function bumpDependencies(targetVersion, options = {}) {
+    const normalizedVersion = normalizeTargetVersion(targetVersion);
+    const cwd = options.cwd || process.cwd();
+
+    const workspaceManifests = getWorkspaceManifestPaths(cwd);
+    const fixtureManifests = getFixtureManifestPaths(cwd);
+
+    const updatedWorkspaceCount = updateManifestFiles(workspaceManifests, (packageJson) => {
+        const updatedDependencies = updateManagedDependencies(packageJson, 'dependencies', normalizedVersion, false);
+        const updatedDevDependencies = updateManagedDependencies(packageJson, 'devDependencies', normalizedVersion, false);
+
+        return updatedDependencies || updatedDevDependencies;
+    });
+
+    const updatedFixtureCount = updateManifestFiles(fixtureManifests, (packageJson) => {
+        let changed = false;
+
+        if (
+            packageJson.accordproject &&
+            typeof packageJson.accordproject === 'object' &&
+            'cicero' in packageJson.accordproject
+        ) {
+            const nextVersion = rewriteVersion(packageJson.accordproject.cicero, normalizedVersion);
+
+            if (packageJson.accordproject.cicero !== nextVersion) {
+                packageJson.accordproject.cicero = nextVersion;
+                changed = true;
+            }
+        }
+
+        const updatedDependencies = updateManagedDependencies(packageJson, 'dependencies', normalizedVersion, true);
+        const updatedDevDependencies = updateManagedDependencies(packageJson, 'devDependencies', normalizedVersion, true);
+
+        return updatedDependencies || updatedDevDependencies || changed;
+    });
+
+    return {
+        targetVersion: normalizedVersion,
+        updatedWorkspaceCount,
+        updatedFixtureCount,
+    };
+}
+
+if (require.main === module) {
+    try {
+        const result = bumpDependencies(process.argv[2]);
+        console.log(
+            `Updated ${result.updatedWorkspaceCount} workspace manifests and ${result.updatedFixtureCount} fixture manifests to ${result.targetVersion}.`
+        );
+    } catch (err) {
+        console.error(err.message);
+        process.exit(1);
+    }
+}
+
+module.exports = {
+    bumpDependencies,
+    getFixtureManifestPaths,
+    getWorkspaceManifestPaths,
+    managedPackageNames,
+    normalizeTargetVersion,
+    rewriteVersion,
+    serializePackageJson,
+};

--- a/scripts/bump_version.js
+++ b/scripts/bump_version.js
@@ -16,242 +16,99 @@
 'use strict';
 
 const fs = require('fs');
-const path = require('path');
 const glob = require('glob');
 const semver = require('semver');
 
 /**
- * This script updates managed Accord Project version references during release.
- * It updates workspace package dependencies and repo-tracked template fixture
- * manifests that declare a Cicero compatibility range or internal package
- * dependency.
+ * This script updates the devDependencies and dependencies in the workspaces
+ * and test fixtures to match the version specified by the given parameter.
+ * The expected parameter should be the tag for the package.
  *
  * Example:
- * node ./scripts/bump_version.js <tag-or-version>
+ * node ./scripts/bump_version.js <tag>
  */
 
-const workspacePattern = 'packages/*/package.json';
+const workspacesPattern = 'packages/*/package.json';
 const fixturePattern = 'packages/*/test/data/**/package.json';
-const fixtureIgnorePatterns = ['**/node_modules/**'];
-const managedPackageNames = [
+const packageNames = [
     '@accordproject/cicero-cli',
     '@accordproject/cicero-core',
     '@accordproject/generator-cicero-template',
 ];
 
 /**
- * @param {string} rawVersion the raw CLI version or tag
- * @returns {string} normalized semver version
- */
-function normalizeTargetVersion(rawVersion) {
-    if (!rawVersion) {
-        throw new Error('A version argument is required.');
-    }
-
-    const targetVersion = rawVersion.replace(/^v/, '');
-
-    if (!semver.valid(targetVersion)) {
-        throw new Error(`Invalid version "${rawVersion}". Expected a semantic version like 0.27.0 or v0.27.0.`);
-    }
-
-    return targetVersion;
-}
-
-/**
- * @param {string} content the original file content
- * @returns {number|null} indentation width, or null for a single-line file
- */
-function detectIndentation(content) {
-    if (!content.includes('\n')) {
-        return null;
-    }
-
-    const match = content.match(/^\s+"/m);
-    return match ? match[0].length - 1 : 2;
-}
-
-/**
- * @param {object} packageJson the package json object
- * @param {string} originalContent the original file content
- * @returns {string} serialized package json preserving the original style
- */
-function serializePackageJson(packageJson, originalContent) {
-    const indentation = detectIndentation(originalContent);
-    const hasTrailingNewline = originalContent.endsWith('\n');
-    const serialized = indentation === null ?
-        JSON.stringify(packageJson) :
-        JSON.stringify(packageJson, null, indentation);
-
-    return hasTrailingNewline ? `${serialized}\n` : serialized;
-}
-
-/**
- * @param {string} currentValue the current version or range
- * @param {string} targetVersion the target version
- * @returns {string} updated version string
- */
-function rewriteVersion(currentValue, targetVersion) {
-    if (typeof currentValue !== 'string') {
-        return currentValue;
-    }
-
-    if (currentValue.startsWith('^') || currentValue.startsWith('~')) {
-        return `${currentValue[0]}${targetVersion}`;
-    }
-
-    return targetVersion;
-}
-
-/**
- * @param {object} packageJson the package json object
+ * @param {object} packageJson package.json content
  * @param {string} depType dependency section to update
- * @param {string} targetVersion target version
- * @param {boolean} preserveRange whether to preserve ^ or ~ from the original value
- * @returns {boolean} true if a dependency was changed
+ * @param {string} targetPackageVersion version to write
+ * @returns {boolean} true if the dependency section changed
  */
-function updateManagedDependencies(packageJson, depType, targetVersion, preserveRange) {
-    let changed = false;
-    const dependencyMap = packageJson[depType];
+function updateManagedDependencies(packageJson, depType, targetPackageVersion) {
+    let updated = false;
 
-    if (!dependencyMap) {
-        return changed;
+    packageNames.forEach((dep) => {
+        if (packageJson[depType] && dep in packageJson[depType] && packageJson[depType][dep] !== targetPackageVersion) {
+            packageJson[depType][dep] = targetPackageVersion;
+            updated = true;
+        }
+    });
+
+    return updated;
+}
+
+function bumpDependencies() {
+    const targetPackageVersion = semver.clean(process.argv[2]);
+
+    if (!targetPackageVersion) {
+        throw new Error(`Invalid version "${process.argv[2]}". Expected a semantic version like 0.27.0 or v0.27.0.`);
     }
 
-    managedPackageNames.forEach((depName) => {
-        if (depName in dependencyMap) {
-            const nextValue = preserveRange ?
-                rewriteVersion(dependencyMap[depName], targetVersion) :
-                targetVersion;
+    const fixturePackageVersion = `^${targetPackageVersion}`;
+    const workspacePackages = glob.sync(workspacesPattern);
+    const fixturePackages = glob.sync(fixturePattern, { ignore: '**/node_modules/**' });
+    let updatedWorkspaceCount = 0;
+    let updatedFixtureCount = 0;
 
-            if (dependencyMap[depName] !== nextValue) {
-                dependencyMap[depName] = nextValue;
-                changed = true;
-            }
+    workspacePackages.forEach((packagePath) => {
+        const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+        let updated = false;
+
+        ['dependencies', 'devDependencies'].forEach((depType) => {
+            updated = updateManagedDependencies(packageJson, depType, targetPackageVersion) || updated;
+        });
+
+        if (updated) {
+            fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf8');
+            updatedWorkspaceCount++;
         }
     });
 
-    return changed;
-}
+    fixturePackages.forEach((packagePath) => {
+        const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+        let updated = false;
 
-/**
- * @param {string} manifestPath path to package.json
- * @returns {{packageJson: object, originalContent: string}} parsed manifest data
- */
-function readManifest(manifestPath) {
-    const originalContent = fs.readFileSync(manifestPath, 'utf8');
-    return {
-        packageJson: JSON.parse(originalContent),
-        originalContent,
-    };
-}
+        if (packageJson.accordproject && packageJson.accordproject.cicero !== fixturePackageVersion) {
+            packageJson.accordproject.cicero = fixturePackageVersion;
+            updated = true;
+        }
 
-/**
- * @param {string[]} manifestPaths package.json file paths
- * @param {(packageJson: object) => boolean} mutateManifest mutator returning whether the manifest changed
- * @returns {number} number of files updated
- */
-function updateManifestFiles(manifestPaths, mutateManifest) {
-    let updatedCount = 0;
+        ['dependencies', 'devDependencies'].forEach((depType) => {
+            updated = updateManagedDependencies(packageJson, depType, fixturePackageVersion) || updated;
+        });
 
-    manifestPaths.forEach((manifestPath) => {
-        const { packageJson, originalContent } = readManifest(manifestPath);
-
-        if (mutateManifest(packageJson)) {
-            fs.writeFileSync(manifestPath, serializePackageJson(packageJson, originalContent), 'utf8');
-            updatedCount++;
+        if (updated) {
+            fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2) + '\n', 'utf8');
+            updatedFixtureCount++;
         }
     });
 
-    return updatedCount;
+    console.log(
+        `Updated ${updatedWorkspaceCount} workspace manifests and ${updatedFixtureCount} fixture manifests to ${targetPackageVersion}.`
+    );
 }
 
-/**
- * @param {string} cwd working directory root
- * @returns {string[]} workspace manifest paths
- */
-function getWorkspaceManifestPaths(cwd) {
-    return glob.sync(workspacePattern, { cwd, nodir: true })
-        .map((manifestPath) => path.join(cwd, manifestPath));
+try {
+    bumpDependencies();
+} catch (err) {
+    console.error(err.message);
+    process.exit(1);
 }
-
-/**
- * @param {string} cwd working directory root
- * @returns {string[]} fixture manifest paths
- */
-function getFixtureManifestPaths(cwd) {
-    return glob.sync(fixturePattern, {
-        cwd,
-        nodir: true,
-        ignore: fixtureIgnorePatterns,
-    }).map((manifestPath) => path.join(cwd, manifestPath));
-}
-
-/**
- * @param {string} targetVersion target version
- * @param {{cwd?: string}} [options] script options
- * @returns {{targetVersion: string, updatedWorkspaceCount: number, updatedFixtureCount: number}} update summary
- */
-function bumpDependencies(targetVersion, options = {}) {
-    const normalizedVersion = normalizeTargetVersion(targetVersion);
-    const cwd = options.cwd || process.cwd();
-
-    const workspaceManifests = getWorkspaceManifestPaths(cwd);
-    const fixtureManifests = getFixtureManifestPaths(cwd);
-
-    const updatedWorkspaceCount = updateManifestFiles(workspaceManifests, (packageJson) => {
-        const updatedDependencies = updateManagedDependencies(packageJson, 'dependencies', normalizedVersion, false);
-        const updatedDevDependencies = updateManagedDependencies(packageJson, 'devDependencies', normalizedVersion, false);
-
-        return updatedDependencies || updatedDevDependencies;
-    });
-
-    const updatedFixtureCount = updateManifestFiles(fixtureManifests, (packageJson) => {
-        let changed = false;
-
-        if (
-            packageJson.accordproject &&
-            typeof packageJson.accordproject === 'object' &&
-            'cicero' in packageJson.accordproject
-        ) {
-            const nextVersion = rewriteVersion(packageJson.accordproject.cicero, normalizedVersion);
-
-            if (packageJson.accordproject.cicero !== nextVersion) {
-                packageJson.accordproject.cicero = nextVersion;
-                changed = true;
-            }
-        }
-
-        const updatedDependencies = updateManagedDependencies(packageJson, 'dependencies', normalizedVersion, true);
-        const updatedDevDependencies = updateManagedDependencies(packageJson, 'devDependencies', normalizedVersion, true);
-
-        return updatedDependencies || updatedDevDependencies || changed;
-    });
-
-    return {
-        targetVersion: normalizedVersion,
-        updatedWorkspaceCount,
-        updatedFixtureCount,
-    };
-}
-
-if (require.main === module) {
-    try {
-        const result = bumpDependencies(process.argv[2]);
-        console.log(
-            `Updated ${result.updatedWorkspaceCount} workspace manifests and ${result.updatedFixtureCount} fixture manifests to ${result.targetVersion}.`
-        );
-    } catch (err) {
-        console.error(err.message);
-        process.exit(1);
-    }
-}
-
-module.exports = {
-    bumpDependencies,
-    getFixtureManifestPaths,
-    getWorkspaceManifestPaths,
-    managedPackageNames,
-    normalizeTargetVersion,
-    rewriteVersion,
-    serializePackageJson,
-};

--- a/scripts/bump_version.test.js
+++ b/scripts/bump_version.test.js
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+
+const { bumpDependencies, normalizeTargetVersion } = require('./bump_version');
+
+/**
+ * @param {string} filePath absolute file path
+ * @param {string} content file content
+ */
+function writeFile(filePath, content) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf8');
+}
+
+/**
+ * @returns {string} temporary repository root
+ */
+function createRepoRoot() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'template-archive-bump-version-'));
+}
+
+test('normalizeTargetVersion accepts bare and v-prefixed versions', () => {
+    assert.equal(normalizeTargetVersion('0.27.0'), '0.27.0');
+    assert.equal(normalizeTargetVersion('v0.27.0'), '0.27.0');
+});
+
+test('bumpDependencies rejects invalid versions', () => {
+    const repoRoot = createRepoRoot();
+    assert.throws(
+        () => bumpDependencies('not-a-version', { cwd: repoRoot }),
+        /Invalid version "not-a-version"/
+    );
+});
+
+test('bumpDependencies updates workspace and fixture manifests while skipping fixture node_modules', () => {
+    const repoRoot = createRepoRoot();
+    const workspaceManifestPath = path.join(repoRoot, 'packages/cicero-cli/package.json');
+    const fixtureManifestPath = path.join(repoRoot, 'packages/cicero-core/test/data/block-join/package.json');
+    const singleLineFixturePath = path.join(repoRoot, 'packages/cicero-cli/test/data/helloworldstate/package.json');
+    const nestedNodeModulesPath = path.join(
+        repoRoot,
+        'packages/cicero-core/test/data/with-node_modules/node_modules/my-model-package/package.json'
+    );
+
+    writeFile(
+        workspaceManifestPath,
+        '{\n  "name": "@accordproject/cicero-cli",\n  "dependencies": {\n    "@accordproject/cicero-core": "0.25.0"\n  },\n  "devDependencies": {\n    "@accordproject/generator-cicero-template": "0.25.0"\n  }\n}\n'
+    );
+    writeFile(
+        fixtureManifestPath,
+        '{\n    "name": "volumediscountolist",\n    "accordproject": {\n        "template": "contract",\n        "cicero": "^0.25.0"\n    },\n    "dependencies": {\n        "@accordproject/cicero-cli": "~0.20.1"\n    },\n    "devDependencies": {\n        "@accordproject/generator-cicero-template": "0.19.0"\n    }\n}\n'
+    );
+    writeFile(
+        singleLineFixturePath,
+        '{"name":"helloworldstate","accordproject":{"template":"clause","cicero":"^0.25.0"}}'
+    );
+    writeFile(
+        nestedNodeModulesPath,
+        '{\n  "name": "my-model-package",\n  "version": "0.0.1",\n  "accordproject": {\n    "cicero": "^9.9.9"\n  },\n  "dependencies": {\n    "@accordproject/cicero-core": "^9.9.9"\n  }\n}\n'
+    );
+
+    const result = bumpDependencies('v1.2.3', { cwd: repoRoot });
+
+    assert.deepEqual(result, {
+        targetVersion: '1.2.3',
+        updatedWorkspaceCount: 1,
+        updatedFixtureCount: 2,
+    });
+
+    const workspaceManifest = JSON.parse(fs.readFileSync(workspaceManifestPath, 'utf8'));
+    assert.equal(workspaceManifest.dependencies['@accordproject/cicero-core'], '1.2.3');
+    assert.equal(workspaceManifest.devDependencies['@accordproject/generator-cicero-template'], '1.2.3');
+
+    const fixtureManifest = JSON.parse(fs.readFileSync(fixtureManifestPath, 'utf8'));
+    assert.equal(fixtureManifest.accordproject.cicero, '^1.2.3');
+    assert.equal(fixtureManifest.dependencies['@accordproject/cicero-cli'], '~1.2.3');
+    assert.equal(fixtureManifest.devDependencies['@accordproject/generator-cicero-template'], '1.2.3');
+
+    const singleLineFixtureContent = fs.readFileSync(singleLineFixturePath, 'utf8');
+    assert.equal(singleLineFixtureContent.includes('\n'), false);
+    assert.equal(JSON.parse(singleLineFixtureContent).accordproject.cicero, '^1.2.3');
+
+    const nestedNodeModulesManifest = JSON.parse(fs.readFileSync(nestedNodeModulesPath, 'utf8'));
+    assert.equal(nestedNodeModulesManifest.accordproject.cicero, '^9.9.9');
+    assert.equal(nestedNodeModulesManifest.dependencies['@accordproject/cicero-core'], '^9.9.9');
+});

--- a/scripts/bump_version.test.js
+++ b/scripts/bump_version.test.js
@@ -18,9 +18,10 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
 const test = require('node:test');
 
-const { bumpDependencies, normalizeTargetVersion } = require('./bump_version');
+const scriptPath = path.join(__dirname, 'bump_version.js');
 
 /**
  * @param {string} filePath absolute file path
@@ -38,24 +39,10 @@ function createRepoRoot() {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'template-archive-bump-version-'));
 }
 
-test('normalizeTargetVersion accepts bare and v-prefixed versions', () => {
-    assert.equal(normalizeTargetVersion('0.27.0'), '0.27.0');
-    assert.equal(normalizeTargetVersion('v0.27.0'), '0.27.0');
-});
-
-test('bumpDependencies rejects invalid versions', () => {
-    const repoRoot = createRepoRoot();
-    assert.throws(
-        () => bumpDependencies('not-a-version', { cwd: repoRoot }),
-        /Invalid version "not-a-version"/
-    );
-});
-
-test('bumpDependencies updates workspace and fixture manifests while skipping fixture node_modules', () => {
+test('bump_version updates workspace and fixture manifests while skipping fixture node_modules', () => {
     const repoRoot = createRepoRoot();
     const workspaceManifestPath = path.join(repoRoot, 'packages/cicero-cli/package.json');
     const fixtureManifestPath = path.join(repoRoot, 'packages/cicero-core/test/data/block-join/package.json');
-    const singleLineFixturePath = path.join(repoRoot, 'packages/cicero-cli/test/data/helloworldstate/package.json');
     const nestedNodeModulesPath = path.join(
         repoRoot,
         'packages/cicero-core/test/data/with-node_modules/node_modules/my-model-package/package.json'
@@ -67,24 +54,19 @@ test('bumpDependencies updates workspace and fixture manifests while skipping fi
     );
     writeFile(
         fixtureManifestPath,
-        '{\n    "name": "volumediscountolist",\n    "accordproject": {\n        "template": "contract",\n        "cicero": "^0.25.0"\n    },\n    "dependencies": {\n        "@accordproject/cicero-cli": "~0.20.1"\n    },\n    "devDependencies": {\n        "@accordproject/generator-cicero-template": "0.19.0"\n    }\n}\n'
-    );
-    writeFile(
-        singleLineFixturePath,
-        '{"name":"helloworldstate","accordproject":{"template":"clause","cicero":"^0.25.0"}}'
+        '{\n  "name": "volumediscountolist",\n  "accordproject": {\n    "template": "contract",\n    "cicero": "^0.25.0"\n  },\n  "dependencies": {\n    "@accordproject/cicero-cli": "^0.20.1"\n  },\n  "devDependencies": {\n    "@accordproject/generator-cicero-template": "^0.19.0"\n  }\n}\n'
     );
     writeFile(
         nestedNodeModulesPath,
         '{\n  "name": "my-model-package",\n  "version": "0.0.1",\n  "accordproject": {\n    "cicero": "^9.9.9"\n  },\n  "dependencies": {\n    "@accordproject/cicero-core": "^9.9.9"\n  }\n}\n'
     );
 
-    const result = bumpDependencies('v1.2.3', { cwd: repoRoot });
-
-    assert.deepEqual(result, {
-        targetVersion: '1.2.3',
-        updatedWorkspaceCount: 1,
-        updatedFixtureCount: 2,
+    const output = execFileSync(process.execPath, [scriptPath, 'v1.2.3'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
     });
+
+    assert.match(output, /Updated 1 workspace manifests and 1 fixture manifests to 1.2.3/);
 
     const workspaceManifest = JSON.parse(fs.readFileSync(workspaceManifestPath, 'utf8'));
     assert.equal(workspaceManifest.dependencies['@accordproject/cicero-core'], '1.2.3');
@@ -92,14 +74,21 @@ test('bumpDependencies updates workspace and fixture manifests while skipping fi
 
     const fixtureManifest = JSON.parse(fs.readFileSync(fixtureManifestPath, 'utf8'));
     assert.equal(fixtureManifest.accordproject.cicero, '^1.2.3');
-    assert.equal(fixtureManifest.dependencies['@accordproject/cicero-cli'], '~1.2.3');
-    assert.equal(fixtureManifest.devDependencies['@accordproject/generator-cicero-template'], '1.2.3');
-
-    const singleLineFixtureContent = fs.readFileSync(singleLineFixturePath, 'utf8');
-    assert.equal(singleLineFixtureContent.includes('\n'), false);
-    assert.equal(JSON.parse(singleLineFixtureContent).accordproject.cicero, '^1.2.3');
+    assert.equal(fixtureManifest.dependencies['@accordproject/cicero-cli'], '^1.2.3');
+    assert.equal(fixtureManifest.devDependencies['@accordproject/generator-cicero-template'], '^1.2.3');
 
     const nestedNodeModulesManifest = JSON.parse(fs.readFileSync(nestedNodeModulesPath, 'utf8'));
     assert.equal(nestedNodeModulesManifest.accordproject.cicero, '^9.9.9');
     assert.equal(nestedNodeModulesManifest.dependencies['@accordproject/cicero-core'], '^9.9.9');
+});
+
+test('bump_version rejects invalid versions', () => {
+    const repoRoot = createRepoRoot();
+    const result = spawnSync(process.execPath, [scriptPath, 'not-a-version'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Invalid version "not-a-version"/);
 });


### PR DESCRIPTION
## Closes #930

## What Changed

This updates the release bump automation so it no longer stops at workspace package manifests.

- extend `scripts/bump_version.js` to update repo-tracked fixture and template `package.json` files under `packages/*/test/data/**`
- update both `accordproject.cicero` and managed internal `@accordproject/*` package references when present
- preserve `^` and `~` range style in fixture manifests while still syncing them to the release version
- skip nested fixture `node_modules` so test data snapshots are not rewritten
- add a focused Node test for the bump script
- document the release-sync behavior in `DEVELOPERS.md`
- correct the remaining stale managed fixture dependency in `packages/cicero-core/test/data/block-join/package.json`

## Why

The publish workflow already invoked `scripts/bump_version.js`, but that script only rewrote workspace dependencies. Template fixtures and test manifests could still retain older Accord Project version references after a release bump, which led to follow-up fixes after publication.

## Impact

Release bumps now keep fixture and template manifests in sync with the package version automatically, which should prevent future post-publish cleanup PRs for stale `accordproject.cicero` and internal `@accordproject/*` references.

## Validation

- `node --test scripts/bump_version.test.js`
- `npm test --workspace packages/cicero-core`
- `npm test --workspace packages/cicero-cli`