### PR TITLE
fix(publish): allow publishing when version already matches the tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: build and publish
         run: |
           node ./scripts/bump_version.js ${{ github.event.release.tag_name }}
-          npm version --workspaces --include-workspace-root --no-git-tag-version --yes --exact ${{ github.event.release.tag_name }}
+          npm version --workspaces --include-workspace-root --no-git-tag-version --allow-same-version ${{ github.event.release.tag_name }}
           npm publish --workspaces --access public --provenance ${{ steps.tag.outputs.tag }} 2>&1
 
       - name: Create PR to increment version

--- a/scripts/tag.js
+++ b/scripts/tag.js
@@ -15,6 +15,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const semver = require('semver');
 const targetVersion = process.argv[2];
 
@@ -26,4 +27,9 @@ if (!semver.valid(targetVersion)) {
 const prerelease = semver.prerelease(targetVersion);
 const tag = prerelease ? 'unstable' : 'latest';
 
-console.log(`::set-output name=tag::--tag=${tag}`);
+const output = `--tag=${tag}`;
+if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=${output}\n`);
+} else {
+    console.log(output);
+}


### PR DESCRIPTION
## Problem
The `v1.0.0` release [failed](https://github.com/accordproject/template-archive/actions/runs/26935761598) at the `build and publish` step:

```
npm version --workspaces --include-workspace-root --no-git-tag-version --yes --exact v1.0.0
npm error Version not changed
```

The monorepo packages were already committed at `1.0.0` (in the TS-migration PR), so the release workflow's attempt to set them to the tag version is a no-op — and npm exits non-zero, aborting before `npm publish` runs.

## Fix
- `npm version` now uses **`--allow-same-version`** (and drops the bogus `--yes`/`--exact` flags that only emitted "Unknown cli config" warnings), so the step succeeds whether or not the repo already matches the release tag.
- `scripts/tag.js` migrated off the deprecated `::set-output` to `$GITHUB_OUTPUT`.

## Re-release
After this merges, delete the `v1.0.0` tag + GitHub release and re-create the release on the updated `main` so the workflow runs with the fixed step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)