### PR TITLE
fix(core): export Script type from cicero-core index

### DIFF
--- a/packages/cicero-core/src/index.ts
+++ b/packages/cicero-core/src/index.ts
@@ -20,7 +20,8 @@ import Clause from './clause';
 import Template from './template';
 import TemplateLoader from './templateloader';
 import TemplateLibrary from './templatelibrary';
+import Script from './script';
 // version is read at runtime to avoid pulling package.json into rootDir
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const version = require('../package.json').version;
-export { Clause, Template, TemplateLoader, TemplateLibrary, version };
+export { Clause, Template, TemplateLoader, TemplateLibrary, Script, version };


### PR DESCRIPTION
### Description
This PR exports the `Script` type from the root `packages/cicero-core/src/index.ts` file. 

Currently, downstream projects (like `template-engine`) that rely on `cicero-core` type definitions are unable to properly import the `Script` type publicly without resorting to internal paths or `@ts-ignore` flags. 

This small fix exposes `Script` alongside `Template`, `Clause`, and other core types to resolve those downstream TypeScript errors.

### Context
Fixes a typing issue encountered in `template-engine` where `TemplateArchiveProcessor.ts` needs access to the `Script` type for validation logic. Here's the mentioned template-engine PR link: 
https://github.com/accordproject/template-engine/pull/164
