### PR TITLE
fix(cicero-core): preserve offline validation in loaders

### DIFF
--- a/packages/cicero-core/src/templateloader.ts
+++ b/packages/cicero-core/src/templateloader.ts
@@ -110,7 +110,10 @@ export default class TemplateLoader {
             template.getLogicManager().addLogicFile(obj.contents, obj.name);
         });
         // check the integrity of the model and logic of the template
-        authorSignature ? template.validate({ verifySignature: options && options.disableSignatureVerification ? false : true }) : template.validate();
+        template.validate({
+            ...options,
+            verifySignature: Boolean(authorSignature && !(options && options.disableSignatureVerification))
+        });
 
         return template; // Returns template
     }
@@ -230,7 +233,10 @@ export default class TemplateLoader {
         });
 
         // check the template
-        authorSignature ? template.validate({ verifySignature: options && options.disableSignatureVerification ? false : true }) : template.validate();
+        template.validate({
+            ...options,
+            verifySignature: Boolean(authorSignature && !(options && options.disableSignatureVerification))
+        });
 
         return template;
     }

--- a/packages/cicero-core/src/templateloader.ts
+++ b/packages/cicero-core/src/templateloader.ts
@@ -112,7 +112,7 @@ export default class TemplateLoader {
         // check the integrity of the model and logic of the template
         template.validate({
             ...options,
-            verifySignature: Boolean(authorSignature && !(options && options.disableSignatureVerification))
+            verifySignature: Boolean(authorSignature && !options?.disableSignatureVerification)
         });
 
         return template; // Returns template
@@ -235,7 +235,7 @@ export default class TemplateLoader {
         // check the template
         template.validate({
             ...options,
-            verifySignature: Boolean(authorSignature && !(options && options.disableSignatureVerification))
+            verifySignature: Boolean(authorSignature && !options?.disableSignatureVerification)
         });
 
         return template;

--- a/packages/cicero-core/test/template.test.ts
+++ b/packages/cicero-core/test/template.test.ts
@@ -177,6 +177,18 @@ describe('Template', () => {
             await expect(Template.fromDirectory('./test/data/latedeliveryandpenalty', options)).resolves.toBeDefined();
         });
 
+        it('should not update external models when loading a directory offline', async () => {
+            const { ModelManager } = require('@accordproject/concerto-core');
+            const updateExternalModels = jest.spyOn(ModelManager.prototype, 'updateExternalModels').mockResolvedValue(undefined);
+
+            try {
+                await Template.fromDirectory('./test/data/latedeliveryandpenalty', { offline: true });
+                expect(updateExternalModels).not.toHaveBeenCalled();
+            } finally {
+                updateExternalModels.mockRestore();
+            }
+        });
+
         it('should throw error when date of the signature is tampered', async () => {
             await expect(Template.fromDirectory('./test/data/verifying-template-signature/helloworldstateTamperDate', options)).rejects.toThrow('Template\'s author signature is invalid!');
         });
@@ -355,6 +367,20 @@ describe('Template', () => {
             const template = await Template.fromDirectory('./test/data/latedeliveryandpenalty');
             const buffer = await template.toArchive('es6');
             await expect(Template.fromArchive(buffer)).resolves.toBeDefined();
+        });
+
+        it('should not update external models when loading an archive offline', async () => {
+            await writeZip('latedeliveryandpenalty');
+            const buffer = fs.readFileSync('./test/data/archives/latedeliveryandpenalty.zip');
+            const { ModelManager } = require('@accordproject/concerto-core');
+            const updateExternalModels = jest.spyOn(ModelManager.prototype, 'updateExternalModels').mockResolvedValue(undefined);
+
+            try {
+                await Template.fromArchive(buffer, { offline: true });
+                expect(updateExternalModels).not.toHaveBeenCalled();
+            } finally {
+                updateExternalModels.mockRestore();
+            }
         });
 
         it('should throw an error if multiple template models are found', async () => {


### PR DESCRIPTION
# Closes N/A
Preserve the `offline` option during final template validation so offline loaders do not trigger external model updates.

### Changes

- Forward loader options into final validation in `Template.fromDirectory()` and `Template.fromArchive()`, preserving signature verification.
- Add regression tests confirming `updateExternalModels()` is not called when `{ offline: true }` is used.
- `Template.fromUrl()` is covered indirectly through its existing delegation to `fromArchive()`.

### Flags

- No public API changes.
- Root `npm test` passed:
  - cicero-cli: 56 passed, 1 skipped
  - cicero-core: 190 passed, 3 skipped
  - generator-cicero-template: 3 passed
- Existing non-blocking warnings remain: unsupported TypeScript parser version and one unrelated `no-console` warning.
- Please include this fix in the next compatible `@accordproject/cicero-core` release.

### Screenshots or Video

Not applicable; this is an internal loader and validation fix covered by automated tests.

### Related Issues

- Issue: No corresponding template-archive issue.
- Pull Request: https://github.com/accordproject/template-engine/pull/154

### Author Checklist

- [x] DCO sign-off present using `--signoff`:
      `Signed-off-by: Rishabh Jain <rishabhj2005@gmail.com>`
- [x] Vital features and changes captured in unit tests
- [x] Commit message follows AP format
- [x] Documentation extension not required; no public API changes
- [x] Merging to `main` from `Rishabh060105:fix-cicero-core-offline-validation`